### PR TITLE
CFLAGS can now be defined per package

### DIFF
--- a/cpm/domain/compilation_recipes/cmake.py
+++ b/cpm/domain/compilation_recipes/cmake.py
@@ -14,6 +14,10 @@ class CMakeBuilder(object):
         self.contents += f'include_directories({" ".join(directories)})\n'
         return self
 
+    def set_source_files_properties(self, sources, property, values):
+        self.contents += f'set_source_files_properties({" ".join(sources)} PROPERTIES {property} {" ".join(values)})\n'
+        return self
+
     def add_object_library(self, name, sources):
         self.contents += f'add_library({name} OBJECT {" ".join(sources)})\n'
         return self

--- a/cpm/domain/compilation_recipes/test_recipe.py
+++ b/cpm/domain/compilation_recipes/test_recipe.py
@@ -35,8 +35,12 @@ class TestRecipe(object):
         cmake_builder = cmake.a_cmake() \
             .minimum_required('3.7') \
             .project(project.name) \
-            .include(project.include_directories) \
-            .add_object_library(project_object_library, self._sources_without_main(project))
+            .include(project.include_directories)
+
+        for package in project.packages:
+            if package.cflags:
+                cmake_builder.set_source_files_properties(package.sources, 'COMPILE_FLAGS', package.cflags)
+        cmake_builder.add_object_library(project_object_library, self._sources_without_main(project))
         for executable, test_file in zip(self.executables, project.tests):
             cmake_builder.add_executable(executable, [test_file], [project_object_library]) \
                 .set_target_properties(executable, 'COMPILE_FLAGS', ['-std=c++11'])

--- a/cpm/domain/plugin_loader.py
+++ b/cpm/domain/plugin_loader.py
@@ -18,10 +18,15 @@ class PluginLoader(object):
         return plugin
 
     def plugin_packages(self, description, plugin_path):
-        if 'packages' in description:
-            for package in description['packages']:
-                yield Package(f'{plugin_path}/{package}')
+        for package in description.get('packages', []):
+            yield self._load_package(package, description['packages'][package], plugin_path)
         return []
+
+    def _load_package(self, package, package_description, plugin_path):
+        if package_description is None:
+            return Package(f'{plugin_path}/{package}')
+        cflags = package_description.get('cflags', [])
+        return Package(f'{plugin_path}/{package}', cflags=cflags)
 
     def plugin_sources(self, packages):
         return [source for package in packages for source in self.all_sources(package.path)]

--- a/cpm/domain/project.py
+++ b/cpm/domain/project.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from pathlib import Path
+from dataclasses import field
 
 PROJECT_ROOT_FILE = 'project.yaml'
 
@@ -13,6 +13,7 @@ class Target:
 @dataclass
 class Package:
     path: str
+    cflags: list = field(default_factory=list)
 
 
 class Project(object):

--- a/cpm/domain/project.py
+++ b/cpm/domain/project.py
@@ -33,8 +33,8 @@ class Project(object):
     def add_plugin(self, plugin):
         self.plugins.append(plugin)
 
-    def add_sources(self, source):
-        self.sources.extend(source)
+    def add_sources(self, sources):
+        self.sources.extend(sources)
 
     def add_tests(self, tests):
         self.tests.extend(tests)

--- a/cpm/domain/project.py
+++ b/cpm/domain/project.py
@@ -13,6 +13,7 @@ class Target:
 @dataclass
 class Package:
     path: str
+    sources: list = field(default_factory=list)
     cflags: list = field(default_factory=list)
 
 

--- a/cpm/domain/project_loader.py
+++ b/cpm/domain/project_loader.py
@@ -15,6 +15,7 @@ class ProjectLoader(object):
         try:
             description = self.yaml_handler.load(PROJECT_ROOT_FILE)
             project = Project(description['project_name'])
+            project.add_sources(['main.cpp'])
             for package in self.project_packages(description):
                 project.add_package(package)
                 project.add_include_directory(self.filesystem.parent_directory(package.path))
@@ -49,14 +50,9 @@ class ProjectLoader(object):
         return []
 
     def load_package(self, package, package_description):
-        if package_description is None:
-            return Package(f'{package}')
+        cflags = package_description.get('cflags', []) if package_description is not None else []
         sources = self.all_sources(package)
-        cflags = package_description.get('cflags', [])
         return Package(f'{package}', sources=sources, cflags=cflags)
-
-    def project_sources(self, packages):
-        return ['main.cpp'] + [source for package in packages for source in self.all_sources(package.path)]
 
     def test_suites(self):
         return self.filesystem.find('tests', 'test_*.cpp')

--- a/cpm/domain/project_loader.py
+++ b/cpm/domain/project_loader.py
@@ -44,10 +44,15 @@ class ProjectLoader(object):
         return []
 
     def project_packages(self, description):
-        if 'packages' in description:
-            for package in description['packages']:
-                yield Package(package)
+        for package in description.get('packages', []):
+            yield self._load_package(package, description['packages'][package])
         return []
+
+    def _load_package(self, package, package_description):
+        if package_description is None:
+            return Package(f'{package}')
+        cflags = package_description.get('cflags', [])
+        return Package(f'{package}', cflags=cflags)
 
     def project_sources(self, packages):
         return ['main.cpp'] + [source for package in packages for source in self.all_sources(package.path)]

--- a/cpm/domain/project_loader.py
+++ b/cpm/domain/project_loader.py
@@ -18,7 +18,7 @@ class ProjectLoader(object):
             for package in self.project_packages(description):
                 project.add_package(package)
                 project.add_include_directory(self.filesystem.parent_directory(package.path))
-            project.add_sources(self.project_sources(project.packages))
+                project.add_sources(package.sources)
             project.add_tests(self.test_suites())
             for target in self.described_targets(description):
                 project.add_target(target)

--- a/cpm/domain/project_loader.py
+++ b/cpm/domain/project_loader.py
@@ -45,14 +45,15 @@ class ProjectLoader(object):
 
     def project_packages(self, description):
         for package in description.get('packages', []):
-            yield self._load_package(package, description['packages'][package])
+            yield self.load_package(package, description['packages'][package])
         return []
 
-    def _load_package(self, package, package_description):
+    def load_package(self, package, package_description):
         if package_description is None:
             return Package(f'{package}')
+        sources = self.all_sources(package)
         cflags = package_description.get('cflags', [])
-        return Package(f'{package}', cflags=cflags)
+        return Package(f'{package}', sources=sources, cflags=cflags)
 
     def project_sources(self, packages):
         return ['main.cpp'] + [source for package in packages for source in self.all_sources(package.path)]

--- a/test/compilation_recipes/test_test_recipe.py
+++ b/test/compilation_recipes/test_test_recipe.py
@@ -109,6 +109,37 @@ class TestTestRecipe(unittest.TestCase):
             call('../../api', 'recipes/tests/api'),
         ])
 
+    def dtest_recipe_generation_with_one_package_with_cflags(self):
+        filesystem = MagicMock()
+        filesystem.directory_exists.return_value = False
+        project = self.xWingConsoleFrontendWithOneTest()
+        project.add_package(Package('api'))
+        recipe = TestRecipe(filesystem)
+
+        recipe.generate(project)
+
+        filesystem.create_directory.assert_called_once_with('recipes/tests')
+        filesystem.create_file.assert_called_once_with(
+            'recipes/tests/CMakeLists.txt',
+
+            'cmake_minimum_required (VERSION 3.7)\n'
+            'project(xWingConsoleFrontend)\n'
+            'include_directories()\n'
+            'add_library(xWingConsoleFrontend_object_library OBJECT )\n'
+            'add_executable(test_suite tests/test_suite.cpp $<TARGET_OBJECTS:xWingConsoleFrontend_object_library>)\n'
+            'set_target_properties(test_suite PROPERTIES COMPILE_FLAGS -std=c++11)\n'
+            'add_custom_target(unit\n'
+            '    COMMAND echo "> Done"\n'
+            '    DEPENDS test_suite\n'
+            ')\n'
+
+        )
+        filesystem.symlink.assert_has_calls([
+            call('../../plugins', 'recipes/tests/plugins'),
+            call('../../tests', 'recipes/tests/tests'),
+            call('../../api', 'recipes/tests/api'),
+        ])
+
     def test_recipe_is_updated_when_recipe_files_are_found(self):
         filesystem = MagicMock()
         filesystem.directory_exists.return_value = True

--- a/test/compilation_recipes/test_test_recipe.py
+++ b/test/compilation_recipes/test_test_recipe.py
@@ -40,7 +40,6 @@ class TestTestRecipe(unittest.TestCase):
             '    COMMAND echo "> Done"\n'
             '    DEPENDS test_suite\n'
             ')\n'
-
         )
         filesystem.symlink.assert_has_calls([
             call('../../plugins', 'recipes/tests/plugins'),
@@ -71,7 +70,6 @@ class TestTestRecipe(unittest.TestCase):
             '    COMMAND echo "> Done"\n'
             '    DEPENDS test_suite_1 test_suite_2\n'
             ')\n'
-
         )
         filesystem.symlink.assert_has_calls([
             call('../../plugins', 'recipes/tests/plugins'),
@@ -101,7 +99,6 @@ class TestTestRecipe(unittest.TestCase):
             '    COMMAND echo "> Done"\n'
             '    DEPENDS test_suite\n'
             ')\n'
-
         )
         filesystem.symlink.assert_has_calls([
             call('../../plugins', 'recipes/tests/plugins'),
@@ -109,11 +106,12 @@ class TestTestRecipe(unittest.TestCase):
             call('../../api', 'recipes/tests/api'),
         ])
 
-    def dtest_recipe_generation_with_one_package_with_cflags(self):
+    def test_recipe_generation_with_one_package_with_cflags(self):
         filesystem = MagicMock()
         filesystem.directory_exists.return_value = False
         project = self.xWingConsoleFrontendWithOneTest()
-        project.add_package(Package('api'))
+        project.add_package(Package('api', sources=['file.cpp'], cflags=['-std=c++11']))
+        project.add_sources(['file.cpp'])
         recipe = TestRecipe(filesystem)
 
         recipe.generate(project)
@@ -125,20 +123,44 @@ class TestTestRecipe(unittest.TestCase):
             'cmake_minimum_required (VERSION 3.7)\n'
             'project(xWingConsoleFrontend)\n'
             'include_directories()\n'
-            'add_library(xWingConsoleFrontend_object_library OBJECT )\n'
+            'set_source_files_properties(file.cpp PROPERTIES COMPILE_FLAGS -std=c++11)\n'
+            'add_library(xWingConsoleFrontend_object_library OBJECT file.cpp)\n'
             'add_executable(test_suite tests/test_suite.cpp $<TARGET_OBJECTS:xWingConsoleFrontend_object_library>)\n'
             'set_target_properties(test_suite PROPERTIES COMPILE_FLAGS -std=c++11)\n'
             'add_custom_target(unit\n'
             '    COMMAND echo "> Done"\n'
             '    DEPENDS test_suite\n'
             ')\n'
-
         )
-        filesystem.symlink.assert_has_calls([
-            call('../../plugins', 'recipes/tests/plugins'),
-            call('../../tests', 'recipes/tests/tests'),
-            call('../../api', 'recipes/tests/api'),
-        ])
+
+    def test_recipe_generation_with_many_packages_with_cflags(self):
+        filesystem = MagicMock()
+        filesystem.directory_exists.return_value = False
+        project = self.xWingConsoleFrontendWithOneTest()
+        project.add_package(Package('api', sources=['api.cpp'], cflags=['-std=c++11']))
+        project.add_package(Package('domain', sources=['domain.cpp'], cflags=['-Wall']))
+        project.add_sources(['api.cpp', 'domain.cpp'])
+        recipe = TestRecipe(filesystem)
+
+        recipe.generate(project)
+
+        filesystem.create_directory.assert_called_once_with('recipes/tests')
+        filesystem.create_file.assert_called_once_with(
+            'recipes/tests/CMakeLists.txt',
+
+            'cmake_minimum_required (VERSION 3.7)\n'
+            'project(xWingConsoleFrontend)\n'
+            'include_directories()\n'
+            'set_source_files_properties(api.cpp PROPERTIES COMPILE_FLAGS -std=c++11)\n'
+            'set_source_files_properties(domain.cpp PROPERTIES COMPILE_FLAGS -Wall)\n'
+            'add_library(xWingConsoleFrontend_object_library OBJECT api.cpp domain.cpp)\n'
+            'add_executable(test_suite tests/test_suite.cpp $<TARGET_OBJECTS:xWingConsoleFrontend_object_library>)\n'
+            'set_target_properties(test_suite PROPERTIES COMPILE_FLAGS -std=c++11)\n'
+            'add_custom_target(unit\n'
+            '    COMMAND echo "> Done"\n'
+            '    DEPENDS test_suite\n'
+            ')\n'
+        )
 
     def test_recipe_is_updated_when_recipe_files_are_found(self):
         filesystem = MagicMock()

--- a/test/domain/test_project_loader.py
+++ b/test/domain/test_project_loader.py
@@ -42,7 +42,7 @@ class TestProjectLoader(unittest.TestCase):
         filesystem.parent_directory.return_value = '.'
         yaml_handler.load.return_value = {
             'project_name': 'Project',
-            'packages': ['cpm-hub'],
+            'packages': {'cpm-hub': None},
         }
         loader = ProjectLoader(yaml_handler, filesystem)
 
@@ -51,6 +51,23 @@ class TestProjectLoader(unittest.TestCase):
         assert project.name == 'Project'
         assert Package(path='cpm-hub') in project.packages
         assert project.include_directories == ['.']
+
+    def test_loading_project_with_one_package_with_cflags(self):
+        yaml_handler = mock.MagicMock()
+        filesystem = mock.MagicMock()
+        yaml_handler.load.return_value = {
+            'project_name': 'Project',
+            'packages': {
+                'cpm-hub': {
+                    'cflags': ['-std=c++11']
+                }
+            },
+        }
+        loader = ProjectLoader(yaml_handler, filesystem)
+
+        project = loader.load()
+
+        assert Package(path='cpm-hub', cflags=['-std=c++11']) in project.packages
 
     def test_loading_project_with_one_target(self):
         yaml_handler = mock.MagicMock()

--- a/test/domain/test_project_loader.py
+++ b/test/domain/test_project_loader.py
@@ -39,6 +39,7 @@ class TestProjectLoader(unittest.TestCase):
     def test_loading_project_with_one_package(self):
         yaml_handler = mock.MagicMock()
         filesystem = mock.MagicMock()
+        filesystem.find.return_value = []
         filesystem.parent_directory.return_value = '.'
         yaml_handler.load.return_value = {
             'project_name': 'Project',
@@ -158,20 +159,6 @@ class TestProjectLoader(unittest.TestCase):
                 'plugins': {'cest': '1.2'}
             }
         )
-
-    def test_finding_project_sources(self):
-        filesystem = mock.MagicMock()
-        filesystem.find.side_effect = [['package/file.cpp'], ['package/file.c']]
-        yaml_handler = mock.MagicMock()
-        loader = ProjectLoader(yaml_handler, filesystem)
-
-        sources = loader.project_sources([Package('package')])
-
-        assert sources == ['main.cpp', 'package/file.cpp', 'package/file.c']
-        filesystem.find.assert_has_calls([
-            mock.call('package', '*.cpp'),
-            mock.call('package', '*.c'),
-        ])
 
     def test_loading_package_with_sources(self):
         filesystem = mock.MagicMock()

--- a/test/domain/test_project_loader.py
+++ b/test/domain/test_project_loader.py
@@ -55,6 +55,7 @@ class TestProjectLoader(unittest.TestCase):
     def test_loading_project_with_one_package_with_cflags(self):
         yaml_handler = mock.MagicMock()
         filesystem = mock.MagicMock()
+        filesystem.find.return_value = []
         yaml_handler.load.return_value = {
             'project_name': 'Project',
             'packages': {
@@ -167,6 +168,20 @@ class TestProjectLoader(unittest.TestCase):
         sources = loader.project_sources([Package('package')])
 
         assert sources == ['main.cpp', 'package/file.cpp', 'package/file.c']
+        filesystem.find.assert_has_calls([
+            mock.call('package', '*.cpp'),
+            mock.call('package', '*.c'),
+        ])
+
+    def test_loading_package_with_sources(self):
+        filesystem = mock.MagicMock()
+        filesystem.find.side_effect = [['package/file.cpp'], ['package/file.c']]
+        yaml_handler = mock.MagicMock()
+        loader = ProjectLoader(yaml_handler, filesystem)
+
+        package = loader.load_package('package', {})
+
+        assert package == Package(path='package', sources=['package/file.cpp', 'package/file.c'])
         filesystem.find.assert_has_calls([
             mock.call('package', '*.cpp'),
             mock.call('package', '*.c'),


### PR DESCRIPTION
Closes #28 

The project.yaml syntax has been extended to support cflags per package. 