### PR TITLE
Add support for specifying libraries to link in project.yaml

### DIFF
--- a/cpm/domain/compilation_recipes/build.py
+++ b/cpm/domain/compilation_recipes/build.py
@@ -40,8 +40,10 @@ class BuildRecipe(CompilationRecipe):
         for package in project.packages:
             if package.cflags:
                 cmake_builder.set_source_files_properties(package.sources, 'COMPILE_FLAGS', package.cflags)
-        cmake_builder.add_executable(project.name, project.sources) \
-            .add_custom_command(
+        cmake_builder.add_executable(project.name, project.sources)
+        if project.link_options.libraries:
+            cmake_builder.target_link_libraries(project.name, project.link_options.libraries)
+        cmake_builder.add_custom_command(
                     project.name,
                     'POST_BUILD',
                     f'${{CMAKE_COMMAND}} -E copy $<TARGET_FILE:{project.name}> ${{PROJECT_SOURCE_DIR}}/../../{project.name}')

--- a/cpm/domain/compilation_recipes/cmake.py
+++ b/cpm/domain/compilation_recipes/cmake.py
@@ -33,6 +33,10 @@ class CMakeBuilder(object):
         self.contents += f'set_target_properties({target} PROPERTIES {property} {" ".join(values)})\n'
         return self
 
+    def target_link_libraries(self, target, libraries):
+        self.contents += f'target_link_libraries({target} {" ".join(libraries)})\n'
+        return self
+
     def add_custom_target(self, target, command, depends):
         self.contents += f'add_custom_target({target}\n' \
                          f'    COMMAND {command}"\n' \

--- a/cpm/domain/compilation_recipes/test_recipe.py
+++ b/cpm/domain/compilation_recipes/test_recipe.py
@@ -44,7 +44,9 @@ class TestRecipe(object):
         cmake_builder.add_object_library(project_object_library, self._sources_without_main(project))
         for executable, test_file in zip(self.executables, project.tests):
             cmake_builder.add_executable(executable, [test_file], [project_object_library]) \
-                .set_target_properties(executable, 'COMPILE_FLAGS', ['-std=c++11'])
+                         .set_target_properties(executable, 'COMPILE_FLAGS', ['-std=c++11'])
+            if project.link_options.libraries:
+                cmake_builder.target_link_libraries(executable, project.link_options.libraries)
         cmake_builder.add_custom_target('unit', 'echo "> Done', self.executables)
         return cmake_builder.contents
 

--- a/cpm/domain/project.py
+++ b/cpm/domain/project.py
@@ -17,6 +17,12 @@ class Package:
     cflags: list = field(default_factory=list)
 
 
+@dataclass
+class LinkOptions:
+    flags: list = field(default_factory=list)
+    libraries: list = field(default_factory=list)
+
+
 class Project(object):
     def __init__(self, name):
         self.name = name
@@ -25,6 +31,7 @@ class Project(object):
         self.sources = []
         self.packages = []
         self.include_directories = []
+        self.link_options = LinkOptions()
         self.targets = {}
 
     def add_target(self, target):
@@ -44,3 +51,6 @@ class Project(object):
 
     def add_include_directory(self, directory):
         self.include_directories.append(directory)
+
+    def add_library(self, library):
+        self.link_options.libraries.append(library)

--- a/cpm/domain/project_loader.py
+++ b/cpm/domain/project_loader.py
@@ -28,6 +28,8 @@ class ProjectLoader(object):
                 project.add_sources(plugin.sources)
                 for directory in plugin.include_directories:
                     project.add_include_directory(directory)
+            for library in self.link_libraries(description):
+                project.add_library(library)
             return project
         except FileNotFoundError:
             raise NotAChromosProject()
@@ -71,6 +73,10 @@ class ProjectLoader(object):
                 plugin.name: plugin.version for plugin in project.plugins
             }
         self.yaml_handler.dump(PROJECT_ROOT_FILE, project_description)
+
+    def link_libraries(self, description):
+        link_options = description.get('link_options', {})
+        return link_options.get('libraries', [])
 
 
 class NotAChromosProject(RuntimeError):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="cpm-cli",
-    version="0.1.1",
+    version="0.1.2",
     scripts=['scripts/cpm'],
     author="Jordi Sánchez",
     description="Chromos Package Manager",

--- a/test/compilation_recipes/test_build_recipe.py
+++ b/test/compilation_recipes/test_build_recipe.py
@@ -34,6 +34,32 @@ class TestBuildRecipe(unittest.TestCase):
             ')\n'
         )
 
+    def test_recipe_generation_with_target_link_libraries(self):
+        filesystem = self.filesystemMockWithoutRecipeFiles()
+        project = self.deathStarBackend()
+        project.add_library('pthread')
+        project.add_library('rt')
+        build_recipe = BuildRecipe(filesystem)
+
+        build_recipe.generate(project)
+
+        filesystem.create_directory.assert_called_once_with('recipes/build')
+        filesystem.symlink.assert_called_once_with('../../main.cpp', 'recipes/build/main.cpp')
+        filesystem.create_file.assert_called_once_with(
+            'recipes/build/CMakeLists.txt',
+
+            'cmake_minimum_required (VERSION 3.7)\n'
+            'project(DeathStarBackend)\n'
+            'include_directories()\n'
+            'add_executable(DeathStarBackend main.cpp)\n'
+            'target_link_libraries(DeathStarBackend pthread rt)\n'
+            'add_custom_command(\n'
+            '    TARGET DeathStarBackend\n'
+            '    POST_BUILD\n'
+            '    COMMAND COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:DeathStarBackend> ${PROJECT_SOURCE_DIR}/../../DeathStarBackend\n'
+            ')\n'
+        )
+
     def test_recipe_generation_with_one_package(self):
         filesystem = self.filesystemMockWithoutRecipeFiles()
         project = self.deathStarBackend()

--- a/test/compilation_recipes/test_test_recipe.py
+++ b/test/compilation_recipes/test_test_recipe.py
@@ -46,6 +46,33 @@ class TestTestRecipe(unittest.TestCase):
             call('../../tests', 'recipes/tests/tests'),
         ])
 
+    def test_recipe_generation_with_one_test_suite_with_target_link_libraries(self):
+        filesystem = MagicMock()
+        filesystem.directory_exists.return_value = False
+        project = self.xWingConsoleFrontendWithOneTest()
+        project.add_include_directory('plugins/cest')
+        project.add_library('pthread')
+        project.add_library('rt')
+        recipe = TestRecipe(filesystem)
+
+        recipe.generate(project)
+
+        filesystem.create_file.assert_called_once_with(
+            'recipes/tests/CMakeLists.txt',
+
+            'cmake_minimum_required (VERSION 3.7)\n'
+            'project(xWingConsoleFrontend)\n'
+            'include_directories(plugins/cest)\n'
+            'add_library(xWingConsoleFrontend_object_library OBJECT )\n'
+            'add_executable(test_suite tests/test_suite.cpp $<TARGET_OBJECTS:xWingConsoleFrontend_object_library>)\n'
+            'set_target_properties(test_suite PROPERTIES COMPILE_FLAGS -std=c++11)\n'
+            'target_link_libraries(test_suite pthread rt)\n'
+            'add_custom_target(unit\n'
+            '    COMMAND echo "> Done"\n'
+            '    DEPENDS test_suite\n'
+            ')\n'
+        )
+
     def test_recipe_generation_with_many_test_suites(self):
         filesystem = MagicMock()
         filesystem.directory_exists.return_value = False


### PR DESCRIPTION
Closes #44 

The current option is now available:

```yaml
link_options:
    libraries: ['pthread']
```

Which will translate into the following CMake rule for both tests and the final binary:

`target_link_libraries(cpm-hub pthread)`