### PR TITLE
27 implement publish command

### DIFF
--- a/cpm/__init__.py
+++ b/cpm/__init__.py
@@ -7,13 +7,17 @@ from cpm.api.target import add_target
 from cpm.api.build import build_project
 from cpm.api.clean import clean_project
 from cpm.api.test import run_tests
+from cpm.api.publish import publish_project
 from cpm.domain.build_service import BuildService
 from cpm.domain.clean_service import CleanService
 from cpm.domain.compilation_recipes.build import BuildRecipe
 from cpm.domain.compilation_recipes.test_recipe import TestRecipe
 from cpm.domain.creation_service import CreationService
 from cpm.domain.creation_service import CreationOptions
+from cpm.domain.plugin_packager import PluginPackager
+from cpm.domain.plugin_uploader import PluginUploader
 from cpm.domain.project_loader import ProjectLoader
+from cpm.domain.publish_service import PublishService
 from cpm.domain.target_service import TargetService
 from cpm.domain.test_service import TestService
 from cpm.infrastructure.filesystem import Filesystem
@@ -27,6 +31,7 @@ def main():
         'clean': clean,
         'target': target,
         'test': test,
+        'publish': publish,
     }
 
     action_parser = argparse.ArgumentParser(description='Chromos Package Manager')
@@ -110,6 +115,19 @@ def test():
     recipe = TestRecipe(filesystem)
 
     result = run_tests(service, recipe, args.patterns)
+
+    finish(result)
+
+
+def publish():
+    filesystem = Filesystem()
+    yaml_handler = YamlHandler(filesystem)
+    loader = ProjectLoader(yaml_handler, filesystem)
+    packager = PluginPackager(filesystem)
+    uploader = PluginUploader()
+    service = PublishService(loader, packager, uploader)
+
+    result = publish_project(service)
 
     finish(result)
 

--- a/cpm/api/publish.py
+++ b/cpm/api/publish.py
@@ -1,0 +1,13 @@
+from cpm.api.result import Result
+from cpm.api.result import OK
+from cpm.api.result import FAIL
+from cpm.domain.project_loader import NotAChromosProject
+
+
+def publish_project(publish_service):
+    try:
+        publish_service.publish()
+    except NotAChromosProject:
+        return Result(FAIL, f'error: not a Chromos project')
+
+    return Result(OK, f'Build finished')

--- a/cpm/api/publish.py
+++ b/cpm/api/publish.py
@@ -13,4 +13,4 @@ def publish_project(publish_service):
     except PackagingFailure as error:
         return Result(FAIL, f'error: {error.cause}')
 
-    return Result(OK, f'Build finished')
+    return Result(OK, f'Project published')

--- a/cpm/api/publish.py
+++ b/cpm/api/publish.py
@@ -1,6 +1,7 @@
 from cpm.api.result import Result
 from cpm.api.result import OK
 from cpm.api.result import FAIL
+from cpm.domain.plugin_packager import PackagingFailure
 from cpm.domain.project_loader import NotAChromosProject
 
 
@@ -8,6 +9,8 @@ def publish_project(publish_service):
     try:
         publish_service.publish()
     except NotAChromosProject:
-        return Result(FAIL, f'error: not a Chromos project')
+        return Result(FAIL, f'error: not a CPM project')
+    except PackagingFailure as error:
+        return Result(FAIL, f'error: {error.cause}')
 
     return Result(OK, f'Build finished')

--- a/cpm/domain/compilation_recipes/cmake.py
+++ b/cpm/domain/compilation_recipes/cmake.py
@@ -15,7 +15,7 @@ class CMakeBuilder(object):
         return self
 
     def set_source_files_properties(self, sources, property, values):
-        self.contents += f'set_source_files_properties({" ".join(sources)} PROPERTIES {property} "{" ".join(values)}")\n'
+        self.contents += f'set_source_files_properties({" ".join(sources)} PROPERTIES {property} {" ".join(values)})\n'
         return self
 
     def add_object_library(self, name, sources):
@@ -30,7 +30,7 @@ class CMakeBuilder(object):
         return self
 
     def set_target_properties(self, target, property, values):
-        self.contents += f'set_target_properties({target} PROPERTIES {property} "{" ".join(values)}")\n'
+        self.contents += f'set_target_properties({target} PROPERTIES {property} {" ".join(values)})\n'
         return self
 
     def target_link_libraries(self, target, libraries):

--- a/cpm/domain/compilation_recipes/cmake.py
+++ b/cpm/domain/compilation_recipes/cmake.py
@@ -15,7 +15,7 @@ class CMakeBuilder(object):
         return self
 
     def set_source_files_properties(self, sources, property, values):
-        self.contents += f'set_source_files_properties({" ".join(sources)} PROPERTIES {property} {" ".join(values)})\n'
+        self.contents += f'set_source_files_properties({" ".join(sources)} PROPERTIES {property} "{" ".join(values)}")\n'
         return self
 
     def add_object_library(self, name, sources):
@@ -30,7 +30,7 @@ class CMakeBuilder(object):
         return self
 
     def set_target_properties(self, target, property, values):
-        self.contents += f'set_target_properties({target} PROPERTIES {property} {" ".join(values)})\n'
+        self.contents += f'set_target_properties({target} PROPERTIES {property} "{" ".join(values)}")\n'
         return self
 
     def target_link_libraries(self, target, libraries):

--- a/cpm/domain/plugin_packager.py
+++ b/cpm/domain/plugin_packager.py
@@ -16,6 +16,10 @@ class PluginPackager(object):
         self.filesystem.copy_file(PROJECT_ROOT_FILE, f'{build_directory}/plugin.yaml')
         for package in project.packages:
             self.filesystem.copy_directory(package.path, f'{build_directory}/{package.path}')
+        self.filesystem.zip(build_directory, f'{project.name}')
+        self.filesystem.remove_directory(build_directory)
+
+        return f'{project.name}.zip'
 
 
 class PackagingFailure(RuntimeError):

--- a/cpm/domain/plugin_packager.py
+++ b/cpm/domain/plugin_packager.py
@@ -1,7 +1,23 @@
+from cpm.domain.project import PROJECT_ROOT_FILE
+
+
 class PluginPackager(object):
-    def collect(self):
-        pass
+    def __init__(self, filesystem):
+        self.filesystem = filesystem
+
+    def pack(self, project, build_directory):
+        if not project.packages:
+            raise PackagingFailure(cause='project contains no packages')
+
+        if self.filesystem.directory_exists(build_directory):
+            raise PackagingFailure(cause='build directory exists')
+
+        self.filesystem.create_directory(build_directory)
+        self.filesystem.copy_file(PROJECT_ROOT_FILE, f'{build_directory}/plugin.yaml')
+        for package in project.packages:
+            self.filesystem.copy_directory(package.path, f'{build_directory}/{package.path}')
 
 
-class PackagingError(RuntimeError):
-    pass
+class PackagingFailure(RuntimeError):
+    def __init__(self, cause='packaging failure'):
+        self.cause = cause

--- a/cpm/domain/plugin_packager.py
+++ b/cpm/domain/plugin_packager.py
@@ -1,0 +1,7 @@
+class PluginPackager(object):
+    def collect(self):
+        pass
+
+
+class PackagingError(RuntimeError):
+    pass

--- a/cpm/domain/plugin_uploader.py
+++ b/cpm/domain/plugin_uploader.py
@@ -1,0 +1,6 @@
+class PluginUploader(object):
+    pass
+
+
+class AuthenticationFailure(RuntimeError):
+    pass

--- a/cpm/domain/plugin_uploader.py
+++ b/cpm/domain/plugin_uploader.py
@@ -2,7 +2,8 @@ from cpm.infrastructure import http_client
 
 
 class PluginUploader(object):
-    def __init__(self, auth_token=''):
+    def __init__(self, auth_token='', repository_url='https://www.cpm-hub.com/plugins'):
+        self.repository_url = repository_url
         self.auth_token = auth_token
 
     def upload(self, file_name):
@@ -13,7 +14,7 @@ class PluginUploader(object):
             'file': open(file_name, 'rb')
         }
 
-        http_client.post('https://www.cpm-hub.com/plugins', files=files, data=data)
+        http_client.post(self.repository_url, files=files, data=data)
 
 
 class AuthenticationFailure(RuntimeError):

--- a/cpm/domain/plugin_uploader.py
+++ b/cpm/domain/plugin_uploader.py
@@ -1,5 +1,19 @@
+from cpm.infrastructure import http_client
+
+
 class PluginUploader(object):
-    pass
+    def __init__(self, auth_token=''):
+        self.auth_token = auth_token
+
+    def upload(self, file_name):
+        data = {
+            'token': self.auth_token,
+        }
+        files = {
+            'file': open(file_name, 'rb')
+        }
+
+        http_client.post('https://www.cpm-hub.com/plugins', files=files, data=data)
 
 
 class AuthenticationFailure(RuntimeError):

--- a/cpm/domain/publish_service.py
+++ b/cpm/domain/publish_service.py
@@ -1,0 +1,10 @@
+class PublishService(object):
+    def __init__(self, project_loader, plugin_packager, plugin_uploader):
+        self.project_loader = project_loader
+        self.plugin_packager = plugin_packager
+        self.plugin_uploader = plugin_uploader
+
+    def publish(self):
+        project = self.project_loader.load()
+        package_name = self.plugin_packager.pack(project, 'dist')
+        self.plugin_uploader.upload(package_name)

--- a/cpm/infrastructure/filesystem.py
+++ b/cpm/infrastructure/filesystem.py
@@ -33,6 +33,9 @@ class Filesystem:
     def find(self, path, pattern):
         return [str(filename) for filename in Path(path).rglob(pattern)]
 
+    def zip(self, directory, output_filename):
+        shutil.make_archive(output_filename, 'zip', directory)
+
     def symlink(self, source, destination):
         if Path(destination).is_symlink():
             return

--- a/cpm/infrastructure/filesystem.py
+++ b/cpm/infrastructure/filesystem.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+from distutils.dir_util import copy_tree
 from pathlib import Path
 
 
@@ -10,6 +11,12 @@ class Filesystem:
     def create_file(self, name, contents=''):
         with open(name, 'w') as f:
             f.write(contents)
+
+    def copy_file(self, origin, destination):
+        shutil.copy2(origin, destination)
+
+    def copy_directory(self, origin, destination):
+        copy_tree(origin, destination)
 
     def directory_exists(self, name):
         return os.path.exists(name) and os.path.isdir(name)

--- a/cpm/infrastructure/http_client.py
+++ b/cpm/infrastructure/http_client.py
@@ -1,0 +1,5 @@
+import requests
+
+
+def post(url, data=None, headers=None, files=None):
+    requests.post(url, files=files, data=data, headers=headers)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 mock
 pyyaml
+requests

--- a/test/api/test_api_create.py
+++ b/test/api/test_api_create.py
@@ -5,7 +5,7 @@ from cpm.api.create import new_project
 from cpm.domain.creation_service import CreationOptions
 
 
-class TestInitApi(unittest.TestCase):
+class TestApiCreate(unittest.TestCase):
     def test_create_project_uses_creation_service_for_initializing_project(self):
         project_constructor = mock.MagicMock()
         project_constructor.exists.return_value = False

--- a/test/api/test_api_publish.py
+++ b/test/api/test_api_publish.py
@@ -1,0 +1,23 @@
+import unittest
+from unittest import mock
+
+from cpm.domain.project_loader import NotAChromosProject
+from cpm.api.publish import publish_project
+
+
+class TestApiPublish(unittest.TestCase):
+    def test_publish_fails_when_current_directory_is_not_a_chromos_project(self):
+        publish_service = mock.MagicMock()
+        publish_service.publish.side_effect = NotAChromosProject()
+
+        result = publish_project(publish_service)
+
+        assert result.status_code == 1
+        publish_service.publish.assert_called_once()
+
+    def test_publish_api(self):
+        publish_service = mock.MagicMock()
+
+        result = publish_project(publish_service)
+
+        assert result.status_code == 0

--- a/test/api/test_api_publish.py
+++ b/test/api/test_api_publish.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest import mock
 
+from cpm.domain.plugin_packager import PackagingFailure
 from cpm.domain.project_loader import NotAChromosProject
 from cpm.api.publish import publish_project
 
@@ -8,7 +9,16 @@ from cpm.api.publish import publish_project
 class TestApiPublish(unittest.TestCase):
     def test_publish_fails_when_current_directory_is_not_a_chromos_project(self):
         publish_service = mock.MagicMock()
-        publish_service.publish.side_effect = NotAChromosProject()
+        publish_service.publish.side_effect = NotAChromosProject
+
+        result = publish_project(publish_service)
+
+        assert result.status_code == 1
+        publish_service.publish.assert_called_once()
+
+    def test_publish_fails_when_project_contains_no_packages(self):
+        publish_service = mock.MagicMock()
+        publish_service.publish.side_effect = PackagingFailure
 
         result = publish_project(publish_service)
 

--- a/test/api/test_api_test.py
+++ b/test/api/test_api_test.py
@@ -8,7 +8,7 @@ from cpm.domain.project_loader import NotAChromosProject
 from cpm.domain.test_service import NoTestsFound
 
 
-class TestApiBuild(unittest.TestCase):
+class TestApiTest(unittest.TestCase):
     def test_run_tests_fails_when_current_directory_is_not_a_chromos_project(self):
         recipe = mock.MagicMock()
         test_service = mock.MagicMock()

--- a/test/domain/test_plugin_packager.py
+++ b/test/domain/test_plugin_packager.py
@@ -1,0 +1,44 @@
+import unittest
+from mock import MagicMock, call
+
+from cpm.domain.plugin_packager import PluginPackager
+from cpm.domain.plugin_packager import PackagingFailure
+from cpm.domain.project import Project, Package
+
+
+class TestPluginPackager(unittest.TestCase):
+    def test_packaging_plugin_raises_exception_when_no_packages_are_declared(self):
+        filesystem = MagicMock()
+        packager = PluginPackager(filesystem)
+        project = Project('cest')
+
+        self.assertRaises(PackagingFailure, packager.pack, project, 'dist')
+
+    def test_packaging_plugin_raises_exception_when_output_directory_exists(self):
+        filesystem = MagicMock()
+        filesystem.directory_exists.return_value = True
+        packager = PluginPackager(filesystem)
+        project = Project('cest')
+        project.add_package(Package('fakeit'))
+
+        self.assertRaises(PackagingFailure, packager.pack, project, 'dist')
+
+    def test_packaging_creates_output_directory(self):
+        filesystem = MagicMock()
+        filesystem.directory_exists.return_value = False
+        packager = PluginPackager(filesystem)
+        project = Project('cest')
+        project.add_package(Package('api'))
+        project.add_package(Package('domain'))
+
+        packager.pack(project, 'dist')
+
+        filesystem.create_directory.assert_called_once_with('dist')
+        filesystem.copy_file.assert_called_once_with('project.yaml', 'dist/plugin.yaml')
+        filesystem.copy_directory.assert_has_calls([
+            call('api', 'dist/api'),
+            call('domain', 'dist/domain'),
+        ])
+
+
+

--- a/test/domain/test_plugin_packager.py
+++ b/test/domain/test_plugin_packager.py
@@ -39,6 +39,8 @@ class TestPluginPackager(unittest.TestCase):
             call('api', 'dist/api'),
             call('domain', 'dist/domain'),
         ])
+        filesystem.zip.assert_called_once_with('dist', 'cest')
+        filesystem.remove_directory.assert_called_once_with('dist')
 
 
 

--- a/test/domain/test_publish_service.py
+++ b/test/domain/test_publish_service.py
@@ -2,9 +2,9 @@ import unittest
 from mock import MagicMock
 
 from cpm.domain.project import Project
-from cpm.domain.project_loader import NotAChromosProject
 from cpm.domain.publish_service import PublishService
-from cpm.domain.plugin_packager import NoPackagesInProject
+from cpm.domain.project_loader import NotAChromosProject
+from cpm.domain.plugin_packager import PackagingFailure
 from cpm.domain.plugin_uploader import AuthenticationFailure
 
 
@@ -23,11 +23,11 @@ class TestPublishService(unittest.TestCase):
         project_loader = MagicMock()
         project_loader.load.return_value = project
         plugin_packager = MagicMock()
-        plugin_packager.pack.side_effect = NoPackagesInProject
+        plugin_packager.pack.side_effect = PackagingFailure
         plugin_uploader = MagicMock()
         service = PublishService(project_loader, plugin_packager, plugin_uploader)
 
-        self.assertRaises(NoPackagesInProject, service.publish)
+        self.assertRaises(PackagingFailure, service.publish)
 
         plugin_packager.pack.assert_called_once_with(project, 'dist')
 

--- a/test/domain/test_publish_service.py
+++ b/test/domain/test_publish_service.py
@@ -4,7 +4,7 @@ from mock import MagicMock
 from cpm.domain.project import Project
 from cpm.domain.project_loader import NotAChromosProject
 from cpm.domain.publish_service import PublishService
-from cpm.domain.plugin_packager import PackagingError
+from cpm.domain.plugin_packager import NoPackagesInProject
 from cpm.domain.plugin_uploader import AuthenticationFailure
 
 
@@ -23,11 +23,11 @@ class TestPublishService(unittest.TestCase):
         project_loader = MagicMock()
         project_loader.load.return_value = project
         plugin_packager = MagicMock()
-        plugin_packager.pack.side_effect = PackagingError
+        plugin_packager.pack.side_effect = NoPackagesInProject
         plugin_uploader = MagicMock()
         service = PublishService(project_loader, plugin_packager, plugin_uploader)
 
-        self.assertRaises(PackagingError, service.publish)
+        self.assertRaises(NoPackagesInProject, service.publish)
 
         plugin_packager.pack.assert_called_once_with(project, 'dist')
 

--- a/test/domain/test_publish_service.py
+++ b/test/domain/test_publish_service.py
@@ -1,0 +1,60 @@
+import unittest
+from mock import MagicMock
+
+from cpm.domain.project import Project
+from cpm.domain.project_loader import NotAChromosProject
+from cpm.domain.publish_service import PublishService
+from cpm.domain.plugin_packager import PackagingError
+from cpm.domain.plugin_uploader import AuthenticationFailure
+
+
+class TestPublishService(unittest.TestCase):
+    def test_publish_service_fails_when_loader_fails_to_load_project(self):
+        project_loader = MagicMock()
+        project_loader.load.side_effect = NotAChromosProject
+        plugin_packager = MagicMock()
+        plugin_uploader = MagicMock()
+        service = PublishService(project_loader, plugin_packager, plugin_uploader)
+
+        self.assertRaises(NotAChromosProject, service.publish)
+
+    def test_publish_service_fails_when_packing_project_fails(self):
+        project = Project('cpm-hub')
+        project_loader = MagicMock()
+        project_loader.load.return_value = project
+        plugin_packager = MagicMock()
+        plugin_packager.pack.side_effect = PackagingError
+        plugin_uploader = MagicMock()
+        service = PublishService(project_loader, plugin_packager, plugin_uploader)
+
+        self.assertRaises(PackagingError, service.publish)
+
+        plugin_packager.pack.assert_called_once_with(project, 'dist')
+
+    def test_publish_service_fails_when_uploading_plugin_fails(self):
+        project = Project('cpm-hub')
+        project_loader = MagicMock()
+        project_loader.load.return_value = project
+        plugin_packager = MagicMock()
+        plugin_packager.pack.return_value = 'plugin_package'
+        plugin_uploader = MagicMock()
+        plugin_uploader.upload.side_effect = AuthenticationFailure
+        service = PublishService(project_loader, plugin_packager, plugin_uploader)
+
+        self.assertRaises(AuthenticationFailure, service.publish)
+
+        plugin_uploader.upload.assert_called_once_with('plugin_package')
+
+    def test_publish_service_loads_project_then_packages_it_and_uploads_it(self):
+        project = Project('cpm-hub')
+        project_loader = MagicMock()
+        project_loader.load.return_value = project
+        plugin_packager = MagicMock()
+        plugin_packager.pack.return_value = 'plugin_package'
+        plugin_uploader = MagicMock()
+        service = PublishService(project_loader, plugin_packager, plugin_uploader)
+
+        service.publish()
+
+        plugin_packager.pack.assert_called_once_with(project, 'dist')
+        plugin_uploader.upload.assert_called_once_with('plugin_package')


### PR DESCRIPTION
This functionality is very preliminary. It currently packs the project descriptor and packages directories into a `zip` file and then uploads it via a `multipart/form-data` request to a predefined URL at `https://www.cpm-hub.com/plugins`. 

Part of #27.