### PR TITLE
implemented support for project actions

### DIFF
--- a/cpm/__init__.py
+++ b/cpm/__init__.py
@@ -5,19 +5,26 @@ import sys
 import pkgutil
 
 import cpm.api
+from cpm.api.project_actions import discover_project_actions
+from cpm.infrastructure.project_action_runner import ProjectActionRunner
 
 
 def main():
-    action = {}
+    actions = {}
+
     for api_action in api_actions():
         module = importlib.import_module(api_action.name)
-        action[module_name(api_action)] = module
+        if hasattr(module, "execute"):
+            actions[module_name(api_action)] = module
+
+    for project_action in discover_project_actions():
+        actions[project_action.name] = ProjectActionRunner(project_action.name, project_action.command)
 
     action_parser = argparse.ArgumentParser(description='Chromos Package Manager')
-    action_parser.add_argument('action', choices=action.keys())
+    action_parser.add_argument('action', choices=actions.keys())
     args = action_parser.parse_args(sys.argv[1:2])
 
-    result = action[args.action].execute(sys.argv[2:])
+    result = actions[args.action].execute(sys.argv[2:])
 
     finish(result)
 

--- a/cpm/api/project_actions.py
+++ b/cpm/api/project_actions.py
@@ -1,0 +1,15 @@
+from cpm.domain.project_loader import ProjectLoader
+from cpm.domain.project_loader import NotAChromosProject
+from cpm.infrastructure.filesystem import Filesystem
+from cpm.infrastructure.yaml_handler import YamlHandler
+
+
+def discover_project_actions():
+    filesystem = Filesystem()
+    project_loader = ProjectLoader(YamlHandler(filesystem), filesystem)
+
+    try:
+        project = project_loader.load()
+        return project.actions
+    except NotAChromosProject:
+        return []

--- a/cpm/domain/project.py
+++ b/cpm/domain/project.py
@@ -23,6 +23,12 @@ class LinkOptions:
     libraries: list = field(default_factory=list)
 
 
+@dataclass
+class ProjectAction(object):
+    name: str
+    command: str
+
+
 class Project(object):
     def __init__(self, name):
         self.name = name
@@ -33,6 +39,7 @@ class Project(object):
         self.packages = []
         self.include_directories = []
         self.link_options = LinkOptions()
+        self.actions = []
         self.targets = {}
 
     def add_target(self, target):
@@ -55,3 +62,6 @@ class Project(object):
 
     def add_library(self, library):
         self.link_options.libraries.append(library)
+
+    def add_action(self, project_action):
+        self.actions.append(project_action)

--- a/cpm/domain/project_loader.py
+++ b/cpm/domain/project_loader.py
@@ -1,5 +1,5 @@
 from cpm.domain.plugin_loader import PluginLoader
-from cpm.domain.project import PROJECT_ROOT_FILE
+from cpm.domain.project import PROJECT_ROOT_FILE, ProjectAction
 from cpm.domain.project import Package
 from cpm.domain.project import Project
 from cpm.domain.project import Target
@@ -30,6 +30,8 @@ class ProjectLoader(object):
                     project.add_include_directory(directory)
             for library in self.link_libraries(description):
                 project.add_library(library)
+            for action in self.project_actions(description):
+                project.add_action(action)
             return project
         except FileNotFoundError:
             raise NotAChromosProject()
@@ -86,6 +88,10 @@ class ProjectLoader(object):
             description['plugins'][new_plugin.name] = new_plugin.version
 
         self.yaml_handler.dump(PROJECT_ROOT_FILE, description)
+
+    def project_actions(self, description):
+        for action in description.get('actions', []):
+            yield ProjectAction(action, description['actions'][action])
 
 
 class NotAChromosProject(RuntimeError):

--- a/cpm/infrastructure/project_action_runner.py
+++ b/cpm/infrastructure/project_action_runner.py
@@ -1,0 +1,16 @@
+import os
+
+from cpm.api.result import Result
+
+
+class ProjectActionRunner(object):
+    def __init__(self, name, command):
+        self.name = name
+        self.command = command
+
+    def __eq__(self, other):
+        return self.name == other.name
+
+    def execute(self, argv):
+        return_code = os.system(self.command)
+        return Result(return_code, f'finished "{self.name}"')

--- a/test/api/test_api_project_actions.py
+++ b/test/api/test_api_project_actions.py
@@ -1,0 +1,34 @@
+import unittest
+
+from mock import MagicMock
+from mock import patch
+
+from cpm.api.project_actions import discover_project_actions
+from cpm.domain.project import Project, ProjectAction
+from cpm.domain.project_loader import NotAChromosProject
+from cpm.infrastructure.project_action_runner import ProjectActionRunner
+
+
+class TestApiProjectActions(unittest.TestCase):
+    @patch("cpm.api.project_actions.ProjectLoader")
+    def test_project_actions_discovers_zero_actions_when_current_directory_is_not_a_cpm_project(self, ProjectLoader):
+        project_loader = MagicMock()
+        ProjectLoader.return_value = project_loader
+        project_loader.load.side_effect = NotAChromosProject
+        assert discover_project_actions() == []
+
+    @patch("cpm.api.project_actions.ProjectLoader")
+    def test_project_actions_discovers_zero_actions_when_project_has_no_actions(self, ProjectLoader):
+        project_loader = MagicMock()
+        ProjectLoader.return_value = project_loader
+        project_loader.load.return_value = Project("cpm-hub")
+        assert discover_project_actions() == []
+
+    @patch("cpm.api.project_actions.ProjectLoader")
+    def test_project_actions_discovers_one_action_when_project_has_one_actions(self, ProjectLoader):
+        project_loader = MagicMock()
+        ProjectLoader.return_value = project_loader
+        project = Project("cpm-hub")
+        project.add_action(ProjectAction("deploy", "sudo make me a sandwich"))
+        project_loader.load.return_value = project
+        assert discover_project_actions() == [ProjectActionRunner("deploy", "sudo make me a sandwich")]

--- a/test/domain/test_project_loader.py
+++ b/test/domain/test_project_loader.py
@@ -3,7 +3,7 @@ import mock
 
 from cpm.domain.project_loader import ProjectLoader
 from cpm.domain.project_loader import NotAChromosProject
-from cpm.domain.project import Project, Package
+from cpm.domain.project import Project, Package, ProjectAction
 from cpm.domain.plugin import Plugin
 from cpm.domain.project import PROJECT_ROOT_FILE
 from cpm.domain.target import Target
@@ -23,7 +23,7 @@ class TestProjectLoader(unittest.TestCase):
 
         self.assertRaises(NotAChromosProject, loader.load)
 
-    def test_loading_project_without_targets(self):
+    def test_loading_project(self):
         yaml_handler = mock.MagicMock()
         filesystem = mock.MagicMock()
         yaml_handler.load.return_value = {
@@ -270,4 +270,21 @@ class TestProjectLoader(unittest.TestCase):
                 }
             }
         )
+
+    def test_loading_project_with_one_action(self):
+        yaml_handler = mock.MagicMock()
+        filesystem = mock.MagicMock()
+        yaml_handler.load.return_value = {
+            'project_name': 'Project',
+            'actions': {
+                'deploy': 'sudo make me a sandwich'
+            }
+        }
+        loader = ProjectLoader(yaml_handler, filesystem)
+
+        loaded_project = loader.load()
+
+        yaml_handler.load.assert_called_once_with(PROJECT_ROOT_FILE)
+        assert loaded_project.name == 'Project'
+        assert loaded_project.actions == [ProjectAction('deploy', 'sudo make me a sandwich')]
 

--- a/test/infrastructure/test_project_action_runner.py
+++ b/test/infrastructure/test_project_action_runner.py
@@ -1,0 +1,17 @@
+import unittest
+from mock import patch
+
+from cpm.api.result import Result
+from cpm.infrastructure.project_action_runner import ProjectActionRunner
+
+
+class TestProjectActionRunner(unittest.TestCase):
+    @patch("cpm.infrastructure.project_action_runner.os")
+    def test_executing_project_action(self, os):
+        action_runner = ProjectActionRunner('deploy', 'docker build')
+        os.system.return_value = 0
+
+        result = action_runner.execute(None)
+
+        os.system.assert_called_once_with('docker build')
+        assert result == Result(0, f'finished "deploy"')


### PR DESCRIPTION
Additional actions apart from the built-in ones can be defined in the project descriptor:

```yaml
project_name: project
actions:
    deploy: "echo Deploy!"
```

The previous description enables a new `deploy` action in the project:

```bash
$ cpm deploy
Deploy!
CPM: finished "deploy"
```

Closes #45 