### PR TITLE
Implemented basic bash completion

### DIFF
--- a/cpm/__init__.py
+++ b/cpm/__init__.py
@@ -21,8 +21,12 @@ def main():
         actions[project_action.name] = ProjectActionRunner(project_action.name, project_action.command)
 
     action_parser = argparse.ArgumentParser(description='Chromos Package Manager')
-    action_parser.add_argument('action', choices=actions.keys())
+    action_parser.add_argument('action', choices=list(actions.keys()) + ['list-actions'])
     args = action_parser.parse_args(sys.argv[1:2])
+
+    if args.action == 'list-actions':
+        print(' '.join(actions.keys()))
+        sys.exit(0)
 
     result = actions[args.action].execute(sys.argv[2:])
 

--- a/scripts/cpm_bash_completion
+++ b/scripts/cpm_bash_completion
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+_cpm_completions()
+{
+  ACTIONS=$(cpm list-actions)
+  COMPREPLY=($(compgen -W "$ACTIONS" "${COMP_WORDS[1]}"))
+}
+
+complete -F _cpm_completions cpm


### PR DESCRIPTION
Implemented a basic script that can be sourced for bash completion:

```bash
$ cpm <tab><tab>
build    clean    create   deploy   install  publish  target   test
...
$ cpm c<tab><tab>
clean   create  
```

This doesn't solve the problem of installing the bash completion script when installing cpm on the system.