### PR TITLE
Store global CPM configuration in user home directory

### DIFF
--- a/cpm/infrastructure/cpm_user_configuration.py
+++ b/cpm/infrastructure/cpm_user_configuration.py
@@ -1,6 +1,6 @@
 GLOBAL_CONFIGURATION_FILENAME = '.cpm.yaml'
 DEFAULT_CONFIGURATION = {
-    'cpm-hub-url': 'http://localhost:8000',
+    'cpm_hub_url': 'http://localhost:8000',
 }
 
 
@@ -12,6 +12,7 @@ class CpmUserConfiguration(object):
         self.configuration = DEFAULT_CONFIGURATION.copy()
 
     def load(self):
+        print(f'loading cpm configuration from {self.global_configuration_file}')
         if self.filesystem.file_exists(self.global_configuration_file):
             configuration = self.yaml_handler.load(self.global_configuration_file)
             self.configuration.update(configuration)

--- a/cpm/infrastructure/cpm_user_configuration.py
+++ b/cpm/infrastructure/cpm_user_configuration.py
@@ -1,0 +1,20 @@
+GLOBAL_CONFIGURATION_FILENAME = '.cpm.yaml'
+DEFAULT_CONFIGURATION = {
+    'cpm-hub-url': 'http://localhost:8000',
+}
+
+
+class CpmUserConfiguration(object):
+    def __init__(self, yaml_handler, filesystem):
+        self.yaml_handler = yaml_handler
+        self.filesystem = filesystem
+        self.global_configuration_file = f'{self.filesystem.home_directory()}/{GLOBAL_CONFIGURATION_FILENAME}'
+        self.configuration = DEFAULT_CONFIGURATION.copy()
+
+    def load(self):
+        if self.filesystem.file_exists(self.global_configuration_file):
+            configuration = self.yaml_handler.load(self.global_configuration_file)
+            self.configuration.update(configuration)
+
+    def __getitem__(self, item):
+        return self.configuration.get(item, '')

--- a/cpm/infrastructure/filesystem.py
+++ b/cpm/infrastructure/filesystem.py
@@ -44,6 +44,9 @@ class Filesystem:
             return next(os.walk(path))[1]
         return []
 
+    def home_directory(self):
+        return str(Path.home())
+
     def find(self, path, pattern):
         return [str(filename) for filename in Path(path).rglob(pattern)]
 

--- a/cpm/infrastructure/http_client.py
+++ b/cpm/infrastructure/http_client.py
@@ -24,7 +24,7 @@ def get(url, data=None, headers=None, files=None):
         response = requests.get(url, files=files, data=data, headers=headers)
         return HttpResponse(response.status_code, response.text)
     except requests.exceptions.ConnectionError:
-        raise HttpConnectionError()
+        raise HttpConnectionError(url)
 
 
 class HttpConnectionError(RuntimeError):

--- a/test/infrastructure/test_cpm_user_configuration.py
+++ b/test/infrastructure/test_cpm_user_configuration.py
@@ -1,0 +1,45 @@
+import unittest
+from mock import MagicMock
+
+from cpm.infrastructure.cpm_user_configuration import CpmUserConfiguration
+from cpm.infrastructure.cpm_user_configuration import GLOBAL_CONFIGURATION_FILENAME
+
+
+class TestCpmUserConfiguration(unittest.TestCase):
+    def test_loading_configuration_uses_defaults_when_global_configuration_file_does_not_exist(self):
+        filesystem = MagicMock()
+        filesystem.file_exists.return_value = False
+        filesystem.home_directory.return_value = '/home/cpmuser'
+        yaml_handler = MagicMock()
+        cpm_user_configuration = CpmUserConfiguration(yaml_handler, filesystem)
+
+        cpm_user_configuration.load()
+
+        assert cpm_user_configuration['cpm-hub-url'] == 'http://localhost:8000'
+        yaml_handler.load.assert_not_called()
+        filesystem.file_exists.assert_called_once_with(f'/home/cpmuser/{GLOBAL_CONFIGURATION_FILENAME}')
+
+    def test_loading_configuration_loads_defaults_on_empty_global_configuration(self):
+        filesystem = MagicMock()
+        yaml_handler = MagicMock()
+        yaml_handler.load.return_value = {}
+        filesystem.file_exists.return_value = True
+        filesystem.home_directory.return_value = '/home/cpmuser'
+        cpm_user_configuration = CpmUserConfiguration(yaml_handler, filesystem)
+
+        cpm_user_configuration.load()
+
+        assert cpm_user_configuration['cpm-hub-url'] == 'http://localhost:8000'
+        yaml_handler.load.assert_called_once_with(f'/home/cpmuser/{GLOBAL_CONFIGURATION_FILENAME}')
+
+    def test_loading_configuration_updates_defaults_with_global_configuration_values(self):
+        filesystem = MagicMock()
+        yaml_handler = MagicMock()
+        filesystem.file_exists.return_value = True
+        yaml_handler.load.return_value = {'cpm-hub-url': 'http://otherserver.com:8000'}
+        cpm_user_configuration = CpmUserConfiguration(yaml_handler, filesystem)
+
+        cpm_user_configuration.load()
+
+        assert cpm_user_configuration['cpm-hub-url'] == 'http://otherserver.com:8000'
+

--- a/test/infrastructure/test_cpm_user_configuration.py
+++ b/test/infrastructure/test_cpm_user_configuration.py
@@ -15,7 +15,7 @@ class TestCpmUserConfiguration(unittest.TestCase):
 
         cpm_user_configuration.load()
 
-        assert cpm_user_configuration['cpm-hub-url'] == 'http://localhost:8000'
+        assert cpm_user_configuration['cpm_hub_url'] == 'http://localhost:8000'
         yaml_handler.load.assert_not_called()
         filesystem.file_exists.assert_called_once_with(f'/home/cpmuser/{GLOBAL_CONFIGURATION_FILENAME}')
 
@@ -29,17 +29,17 @@ class TestCpmUserConfiguration(unittest.TestCase):
 
         cpm_user_configuration.load()
 
-        assert cpm_user_configuration['cpm-hub-url'] == 'http://localhost:8000'
+        assert cpm_user_configuration['cpm_hub_url'] == 'http://localhost:8000'
         yaml_handler.load.assert_called_once_with(f'/home/cpmuser/{GLOBAL_CONFIGURATION_FILENAME}')
 
     def test_loading_configuration_updates_defaults_with_global_configuration_values(self):
         filesystem = MagicMock()
         yaml_handler = MagicMock()
         filesystem.file_exists.return_value = True
-        yaml_handler.load.return_value = {'cpm-hub-url': 'http://otherserver.com:8000'}
+        yaml_handler.load.return_value = {'cpm_hub_url': 'http://otherserver.com:8000'}
         cpm_user_configuration = CpmUserConfiguration(yaml_handler, filesystem)
 
         cpm_user_configuration.load()
 
-        assert cpm_user_configuration['cpm-hub-url'] == 'http://otherserver.com:8000'
+        assert cpm_user_configuration['cpm_hub_url'] == 'http://otherserver.com:8000'
 


### PR DESCRIPTION
This pull requests allows the user to configure the CPM Hub url to use in a file in its home directory. That file must have the name `.cpm.yaml` and must be located in the user home directory (`~/.cpm.yaml`).

The file is a YAML formatted file and currently it supports the following syntax:

```yaml
cpm_hub_url: http://localhost:8000
```

Closes #58 