### PR TITLE
Process compilation errors for build and test commands

### DIFF
--- a/cpm/api/build.py
+++ b/cpm/api/build.py
@@ -2,7 +2,7 @@ from cpm.api.result import Result
 from cpm.api.result import OK
 from cpm.api.result import FAIL
 from cpm.domain.build_service import BuildService
-from cpm.domain.cmake_recipe import CMakeRecipe
+from cpm.domain.cmake_recipe import CMakeRecipe, CompilationError
 from cpm.domain.project_loader import NotAChromosProject
 from cpm.domain.project_loader import ProjectLoader
 from cpm.infrastructure.filesystem import Filesystem
@@ -14,6 +14,8 @@ def build_project(build_service, recipe):
         build_service.build(recipe)
     except NotAChromosProject:
         return Result(FAIL, f'error: not a Chromos project')
+    except CompilationError:
+        return Result(FAIL, f'error: compilation failed')
 
     return Result(OK, f'Build finished')
 

--- a/cpm/api/test.py
+++ b/cpm/api/test.py
@@ -20,7 +20,7 @@ def run_tests(test_service, recipe, patterns=[]):
     except NotAChromosProject:
         return Result(FAIL, 'error: not a Chromos project')
     except CompilationError as e:
-        return Result(FAIL, f'error: {str(e)}')
+        return Result(FAIL, f'error: compilation failed')
     except TestsFailed:
         return Result(FAIL, '✖ FAIL')
     except NoTestsFound:

--- a/cpm/domain/cmake_recipe.py
+++ b/cpm/domain/cmake_recipe.py
@@ -83,14 +83,8 @@ class CMakeRecipe(object):
             raise CompilationError()
 
     def build_tests(self):
-        subprocess.run(
-            [self.CMAKE_COMMAND, '-G', 'Ninja', '..'],
-            cwd=BUILD_DIRECTORY
-        )
-        subprocess.run(
-            ['ninja', 'test'],
-            cwd=BUILD_DIRECTORY
-        )
+        self.run_compile_command(self.CMAKE_COMMAND, '-G', 'Ninja', '..')
+        self.run_compile_command('ninja', 'test')
 
     def run_tests(self):
         test_results = [self.run_test(executable) for executable in self.test_executables]

--- a/cpm/domain/cmake_recipe.py
+++ b/cpm/domain/cmake_recipe.py
@@ -74,14 +74,13 @@ class CMakeRecipe(object):
         return list(filter(lambda x: x != "main.cpp", project.sources))
 
     def build(self, project):
-        subprocess.run(
-            [self.CMAKE_COMMAND, '-G', 'Ninja', '..'],
-            cwd=BUILD_DIRECTORY
-        )
-        subprocess.run(
-            ['ninja', project.name],
-            cwd=BUILD_DIRECTORY
-        )
+        self.run_compile_command(self.CMAKE_COMMAND, '-G', 'Ninja', '..')
+        self.run_compile_command('ninja', project.name)
+
+    def run_compile_command(self, *args):
+        result = subprocess.run([*args], cwd=BUILD_DIRECTORY)
+        if result.returncode != 0:
+            raise CompilationError()
 
     def build_tests(self):
         subprocess.run(

--- a/test/api/test_api_build.py
+++ b/test/api/test_api_build.py
@@ -25,7 +25,7 @@ class TestApiBuild(unittest.TestCase):
         result = build_project(build_service, recipe)
 
         assert result.status_code == 1
-        build_service.build.assert_called_once_with(recipe, [])
+        build_service.build.assert_called_once_with(recipe)
 
     def test_build_project(self):
         build_service = mock.MagicMock()

--- a/test/api/test_api_build.py
+++ b/test/api/test_api_build.py
@@ -2,6 +2,7 @@ import unittest
 import mock
 
 from cpm.api.build import build_project
+from cpm.domain.cmake_recipe import CompilationError
 from cpm.domain.project_loader import NotAChromosProject
 
 
@@ -15,6 +16,16 @@ class TestApiBuild(unittest.TestCase):
 
         assert result.status_code == 1
         build_service.build.assert_called_once_with(recipe)
+
+    def test_run_tests_fails_when_compilation_fails(self):
+        recipe = mock.MagicMock()
+        build_service = mock.MagicMock()
+        build_service.build.side_effect = CompilationError()
+
+        result = build_project(build_service, recipe)
+
+        assert result.status_code == 1
+        build_service.build.assert_called_once_with(recipe, [])
 
     def test_build_project(self):
         build_service = mock.MagicMock()

--- a/test/domain/test_cmake_recipe.py
+++ b/test/domain/test_cmake_recipe.py
@@ -360,8 +360,8 @@ class TestCMakeRecipe(unittest.TestCase):
     @patch('subprocess.run')
     def test_recipe_builds_tests_with_cmake_and_ninja(self, subprocess_run):
         filesystem = self.filesystemMockWithoutRecipeFiles()
-        project = _project_without_sources('DeathStarBackend')
         cmake_recipe = CMakeRecipe(filesystem)
+        subprocess_run.side_effect = [CompletedProcess(None, 0), CompletedProcess(None, 0)]
 
         cmake_recipe.build_tests()
 
@@ -375,6 +375,22 @@ class TestCMakeRecipe(unittest.TestCase):
                 cwd='build'
             )
         ])
+
+    @patch('subprocess.run')
+    def test_build_tests_raises_exception_when_cmake_command_fails(self, subprocess_run):
+        filesystem = self.filesystemMockWithoutRecipeFiles()
+        cmake_recipe = CMakeRecipe(filesystem)
+        subprocess_run.return_value = CompletedProcess(None, -1)
+
+        self.assertRaises(CompilationError, cmake_recipe.build_tests)
+
+    @patch('subprocess.run')
+    def test_build_tests_raises_exception_when_ninja_command_fails(self, subprocess_run):
+        filesystem = self.filesystemMockWithoutRecipeFiles()
+        cmake_recipe = CMakeRecipe(filesystem)
+        subprocess_run.side_effect = [CompletedProcess(None, 0), CompletedProcess(None, -1)]
+
+        self.assertRaises(CompilationError, cmake_recipe.build_tests)
 
     @patch('subprocess.run')
     def test_recipe_runs_list_of_generated_executable_for_project_with_one_test(self, subprocess_run):

--- a/test/domain/test_cmake_recipe.py
+++ b/test/domain/test_cmake_recipe.py
@@ -5,7 +5,7 @@ from mock import call
 from mock import patch
 
 from subprocess import CompletedProcess
-from cpm.domain.cmake_recipe import CMakeRecipe, TestsFailed, BUILD_DIRECTORY, CMAKELISTS
+from cpm.domain.cmake_recipe import CMakeRecipe, TestsFailed, BUILD_DIRECTORY, CMAKELISTS, CompilationError
 from cpm.domain.plugin import Plugin
 from cpm.domain.project import Project, Package
 
@@ -324,6 +324,7 @@ class TestCMakeRecipe(unittest.TestCase):
         filesystem = self.filesystemMockWithoutRecipeFiles()
         project = _project_without_sources('DeathStarBackend')
         cmake_recipe = CMakeRecipe(filesystem)
+        subprocess_run.side_effect = [CompletedProcess(None, 0), CompletedProcess(None, 0)]
 
         cmake_recipe.build(project)
 
@@ -337,6 +338,24 @@ class TestCMakeRecipe(unittest.TestCase):
                 cwd='build'
             )
         ])
+
+    @patch('subprocess.run')
+    def test_build_raises_an_exception_when_cmake_command_fails(self, subprocess_run):
+        filesystem = self.filesystemMockWithoutRecipeFiles()
+        project = _project_without_sources('DeathStarBackend')
+        cmake_recipe = CMakeRecipe(filesystem)
+        subprocess_run.return_value = CompletedProcess(None, -1)
+
+        self.assertRaises(CompilationError, cmake_recipe.build, project)
+
+    @patch('subprocess.run')
+    def test_build_raises_an_exception_when_ninja_command_fails(self, subprocess_run):
+        filesystem = self.filesystemMockWithoutRecipeFiles()
+        project = _project_without_sources('DeathStarBackend')
+        cmake_recipe = CMakeRecipe(filesystem)
+        subprocess_run.side_effect = [CompletedProcess(None, 0), CompletedProcess(None, -1)]
+
+        self.assertRaises(CompilationError, cmake_recipe.build, project)
 
     @patch('subprocess.run')
     def test_recipe_builds_tests_with_cmake_and_ninja(self, subprocess_run):


### PR DESCRIPTION
This MR processes compilation errors in both build and test commands. A compilation error will stop further commands from being executed.

Closes #89 