### PR TITLE
Fix tests reported as passed when running with file pattern

### DIFF
--- a/cpm/domain/cmake_recipe.py
+++ b/cpm/domain/cmake_recipe.py
@@ -86,8 +86,11 @@ class CMakeRecipe(object):
         self.run_compile_command(self.CMAKE_COMMAND, '-G', 'Ninja', '..')
         self.run_compile_command('ninja', 'test')
 
-    def run_tests(self):
-        test_results = [self.run_test(executable) for executable in self.test_executables]
+    def run_all_tests(self):
+        self.run_tests(self.test_executables)
+
+    def run_tests(self, executables):
+        test_results = [self.run_test(executable) for executable in executables]
         if any(result.returncode != 0 for result in test_results):
             raise TestsFailed('tests failed')
 
@@ -97,7 +100,7 @@ class CMakeRecipe(object):
             cwd=BUILD_DIRECTORY
         )
         if result.returncode < 0:
-            print(f'{executable} failed with signal {result.returncode} ({signal.Signals(-result.returncode).name})')
+            print(f'{executable} failed with {result.returncode} ({signal.Signals(-result.returncode).name})')
         return result
 
     def clean(self):

--- a/cpm/domain/test_service.py
+++ b/cpm/domain/test_service.py
@@ -9,17 +9,16 @@ class TestService(object):
         recipe.generate(project)
         recipe.build_tests()
         if not patterns:
-            recipe.run_tests()
+            recipe.run_all_tests()
         else:
             self.run_matching_tests(recipe, patterns)
 
     def run_matching_tests(self, recipe, patterns):
-        tests = filter(
+        tests = list(filter(
             lambda exe: any(pattern in exe for pattern in patterns),
             recipe.test_executables
-        )
-        for test in tests:
-            recipe.run_test(test)
+        ))
+        recipe.run_tests(tests)
 
 
 class NoTestsFound(RuntimeError):

--- a/test/domain/test_cmake_recipe.py
+++ b/test/domain/test_cmake_recipe.py
@@ -399,7 +399,7 @@ class TestCMakeRecipe(unittest.TestCase):
         recipe.test_executables = ['test_suite']
         subprocess_run.return_value = CompletedProcess(None, 0)
 
-        recipe.run_tests()
+        recipe.run_all_tests()
 
         subprocess_run.assert_has_calls([
             call(
@@ -415,7 +415,7 @@ class TestCMakeRecipe(unittest.TestCase):
         recipe.test_executables = ['test_suite_1', 'test_suite_2']
         subprocess_run.side_effect = [CompletedProcess(None, 0), CompletedProcess(None, 0)]
 
-        recipe.run_tests()
+        recipe.run_all_tests()
 
         subprocess_run.assert_has_calls([
             call(
@@ -435,7 +435,7 @@ class TestCMakeRecipe(unittest.TestCase):
         recipe.test_executables = ['test_suite']
         subprocess_run.return_value = CompletedProcess(None, -1)
 
-        self.assertRaises(TestsFailed, recipe.run_tests)
+        self.assertRaises(TestsFailed, recipe.run_all_tests)
 
     @patch('subprocess.run')
     def test_recipe_runs_all_tests_before_raising_exception_when_tests_fail(self, subprocess_run):
@@ -444,7 +444,7 @@ class TestCMakeRecipe(unittest.TestCase):
         recipe.test_executables = ['test_suite_1', 'test_suite_2']
         subprocess_run.side_effect = [CompletedProcess(None, -1), CompletedProcess(None, 0)]
 
-        self.assertRaises(TestsFailed, recipe.run_tests)
+        self.assertRaises(TestsFailed, recipe.run_all_tests)
 
         subprocess_run.assert_has_calls([
             call(

--- a/test/domain/test_test_service.py
+++ b/test/domain/test_test_service.py
@@ -33,7 +33,7 @@ class TestTestService(unittest.TestCase):
         project_loader.load.assert_called_once()
         test_recipe.generate.assert_not_called()
         test_recipe.build_tests.assert_not_called()
-        test_recipe.run_tests.assert_not_called()
+        test_recipe.run_all_tests.assert_not_called()
 
     def test_service_generates_the_recipe_then_compiles_and_runs_the_tests(self):
         test_recipe = mock.MagicMock()
@@ -48,7 +48,7 @@ class TestTestService(unittest.TestCase):
         project_loader.load.assert_called_once()
         test_recipe.generate.assert_called_once_with(project)
         test_recipe.build_tests.assert_called_once()
-        test_recipe.run_tests.assert_called_once()
+        test_recipe.run_all_tests.assert_called_once()
 
     def test_service_runs_one_test_when_one_executable_matches_one_pattern(self):
         test_recipe = mock.MagicMock()
@@ -61,8 +61,8 @@ class TestTestService(unittest.TestCase):
 
         service.run_tests(test_recipe, patterns=['test_one'])
 
-        test_recipe.run_tests.assert_not_called()
-        test_recipe.run_test.assert_called_once_with('test_one')
+        test_recipe.run_all_tests.assert_not_called()
+        test_recipe.run_tests.assert_called_once_with(['test_one'])
 
     def test_service_runs_no_tests_when_one_executable_doesnt_match_one_pattern(self):
         test_recipe = mock.MagicMock()
@@ -75,7 +75,7 @@ class TestTestService(unittest.TestCase):
 
         service.run_tests(test_recipe, patterns=['unmatched_pattern'])
 
-        test_recipe.run_tests.assert_not_called()
+        test_recipe.run_all_tests.assert_not_called()
         test_recipe.run_test.assert_not_called()
 
     def test_service_runs_many_tests_when_many_executables_matches_one_pattern(self):
@@ -89,11 +89,8 @@ class TestTestService(unittest.TestCase):
 
         service.run_tests(test_recipe, patterns=['test_api'])
 
-        test_recipe.run_tests.assert_not_called()
-        test_recipe.run_test.assert_has_calls([
-            mock.call('test_api_one'),
-            mock.call('test_api_two'),
-        ])
+        test_recipe.run_all_tests.assert_not_called()
+        test_recipe.run_tests.assert_called_once_with(['test_api_one', 'test_api_two'])
 
     def test_service_runs_many_tests_when_many_executables_matches_many_patterns(self):
         test_recipe = mock.MagicMock()
@@ -106,8 +103,5 @@ class TestTestService(unittest.TestCase):
 
         service.run_tests(test_recipe, patterns=['test_api_one', 'test_api_two'])
 
-        test_recipe.run_tests.assert_not_called()
-        test_recipe.run_test.assert_has_calls([
-            mock.call('test_api_one'),
-            mock.call('test_api_two'),
-        ])
+        test_recipe.run_all_tests.assert_not_called()
+        test_recipe.run_tests.assert_called_once_with(['test_api_one', 'test_api_two'])


### PR DESCRIPTION
This MR refactors the test run function at cmake recipe. It fixes the existing problem when running tests using patterns. Individual failures are not taken into account.

Closes #73 