### PR TITLE
Allow user to define global compile flags

### DIFF
--- a/cpm/domain/cmake.py
+++ b/cpm/domain/cmake.py
@@ -22,6 +22,10 @@ class CMakeBuilder(object):
         self.contents += f'add_library({name} OBJECT {" ".join(sources)})\n'
         return self
 
+    def add_static_library(self, name, sources):
+        self.contents += f'add_library({name} STATIC {" ".join(sources)})\n'
+        return self
+
     def add_executable(self, name, sources, object_libraries=[]):
         self.contents += f'add_executable({name} {" ".join(sources)}'
         for library in object_libraries:

--- a/cpm/domain/cmake.py
+++ b/cpm/domain/cmake.py
@@ -1,3 +1,6 @@
+from collections import OrderedDict
+
+
 class CMakeBuilder(object):
     def __init__(self):
         self.contents = ''
@@ -11,8 +14,11 @@ class CMakeBuilder(object):
         return self
 
     def include(self, directories):
-        self.contents += f'include_directories({" ".join(directories)})\n'
+        self.contents += f'include_directories({" ".join(self.no_duplicates(directories))})\n'
         return self
+
+    def no_duplicates(self, directories):
+        return list(OrderedDict.fromkeys(directories))
 
     def set_source_files_properties(self, sources, property, values):
         self.contents += f'set_source_files_properties({" ".join(sources)} PROPERTIES {property} "{" ".join(values)}")\n'

--- a/cpm/domain/cmake_recipe.py
+++ b/cpm/domain/cmake_recipe.py
@@ -66,6 +66,8 @@ class CMakeRecipe(object):
         for plugin in project.plugins:
             self.__generate_plugin_build_rules(cmake_builder, plugin)
         cmake_builder.add_executable(project.name, project.sources)
+        if project.compile_flags:
+            cmake_builder.set_target_properties(project.name, 'COMPILE_FLAGS', project.compile_flags)
         self.__generate_link_libraries_rule(cmake_builder, project)
 
     def __generate_link_libraries_rule(self, cmake_builder, project):

--- a/cpm/domain/project.py
+++ b/cpm/domain/project.py
@@ -37,6 +37,7 @@ class Project(object):
         self.plugins = []
         self.sources = []
         self.packages = []
+        self.compile_flags = []
         self.include_directories = []
         self.link_options = LinkOptions()
         self.actions = []
@@ -65,3 +66,6 @@ class Project(object):
 
     def add_action(self, project_action):
         self.actions.append(project_action)
+
+    def add_compile_flags(self, compile_flags):
+        self.compile_flags.extend(compile_flags)

--- a/cpm/domain/project_loader.py
+++ b/cpm/domain/project_loader.py
@@ -29,10 +29,11 @@ class ProjectLoader(object):
                 project.add_sources(plugin.sources)
                 for directory in plugin.include_directories:
                     project.add_include_directory(directory)
-                for package in plugin.packages:
-                    project.add_package(package)
+                #for package in plugin.packages:
+                #    project.add_package(package)
             for library in self.link_libraries(description):
                 project.add_library(library)
+            project.add_compile_flags(self.compile_flags(description))
             for action in self.project_actions(description):
                 project.add_action(action)
             return project
@@ -78,6 +79,9 @@ class ProjectLoader(object):
     def project_actions(self, description):
         for action in description.get('actions', []):
             yield ProjectAction(action, description['actions'][action])
+
+    def compile_flags(self, description):
+        return description.get('compile_flags', [])
 
 
 class NotAChromosProject(RuntimeError):

--- a/cpm/domain/project_loader.py
+++ b/cpm/domain/project_loader.py
@@ -29,8 +29,6 @@ class ProjectLoader(object):
                 project.add_sources(plugin.sources)
                 for directory in plugin.include_directories:
                     project.add_include_directory(directory)
-                #for package in plugin.packages:
-                #    project.add_package(package)
             for library in self.link_libraries(description):
                 project.add_library(library)
             project.add_compile_flags(self.compile_flags(description))

--- a/cpm/domain/project_loader.py
+++ b/cpm/domain/project_loader.py
@@ -26,7 +26,6 @@ class ProjectLoader(object):
                 project.add_target(target)
             for plugin in self.load_local_plugins():
                 project.add_plugin(plugin)
-                project.add_sources(plugin.sources)
                 for directory in plugin.include_directories:
                     project.add_include_directory(directory)
             for library in self.link_libraries(description):

--- a/cpm/infrastructure/cpm_user_configuration.py
+++ b/cpm/infrastructure/cpm_user_configuration.py
@@ -12,7 +12,6 @@ class CpmUserConfiguration(object):
         self.configuration = DEFAULT_CONFIGURATION.copy()
 
     def load(self):
-        print(f'loading cpm configuration from {self.global_configuration_file}')
         if self.filesystem.file_exists(self.global_configuration_file):
             configuration = self.yaml_handler.load(self.global_configuration_file)
             self.configuration.update(configuration)

--- a/test/domain/test_cmake_recipe.py
+++ b/test/domain/test_cmake_recipe.py
@@ -71,6 +71,27 @@ class TestCMakeRecipe(unittest.TestCase):
             'add_executable(DeathStarBackend main.cpp)\n'
         )
 
+    def test_recipe_generation_with_one_package_with_global_compile_flags(self):
+        filesystem = self.filesystemMockWithoutRecipeFiles()
+        project = _project_without_sources('DeathStarBackend')
+        project.add_package(Package('package', sources=['package.cpp']))
+        project.add_include_directory('package')
+        project.add_sources(['package.cpp'])
+        project.compile_flags = ['-g']
+        cmake_recipe = CMakeRecipe(filesystem)
+
+        cmake_recipe.generate(project)
+
+        filesystem.create_file.assert_called_once_with(
+            'CMakeLists.txt',
+
+            'cmake_minimum_required (VERSION 3.7)\n'
+            'project(DeathStarBackend)\n'
+            'include_directories(package)\n'
+            'add_executable(DeathStarBackend main.cpp package.cpp)\n'
+            'set_target_properties(DeathStarBackend PROPERTIES COMPILE_FLAGS "-g")\n'
+        )
+
     def test_recipe_generation_with_one_package_with_cflags(self):
         filesystem = self.filesystemMockWithoutRecipeFiles()
         project = _project_without_sources('DeathStarBackend')

--- a/test/domain/test_cmake_recipe.py
+++ b/test/domain/test_cmake_recipe.py
@@ -133,6 +133,23 @@ class TestCMakeRecipe(unittest.TestCase):
             'target_link_libraries(DeathStarBackend cest)\n'
         )
 
+    def test_recipe_generation_with_one_plugin_without_sources(self):
+        filesystem = self.filesystemMockWithoutRecipeFiles()
+        project = _project_with_one_plugin('DeathStarBackend')
+        cmake_recipe = CMakeRecipe(filesystem)
+
+        cmake_recipe.generate(project)
+
+        filesystem.create_directory.assert_called_once_with('build')
+        filesystem.create_file.assert_called_once_with(
+            'CMakeLists.txt',
+
+            'cmake_minimum_required (VERSION 3.7)\n'
+            'project(DeathStarBackend)\n'
+            'include_directories()\n'
+            'add_executable(DeathStarBackend main.cpp)\n'
+        )
+
     def test_recipe_generation_with_one_plugin_with_a_package_with_cflags(self):
         filesystem = self.filesystemMockWithoutRecipeFiles()
         project = _project_with_one_plugin('DeathStarBackend', sources=['plugin.cpp'], cflags=['-DDEFINE'])

--- a/test/domain/test_cmake_recipe.py
+++ b/test/domain/test_cmake_recipe.py
@@ -116,7 +116,7 @@ class TestCMakeRecipe(unittest.TestCase):
 
     def test_recipe_generation_with_one_plugin(self):
         filesystem = self.filesystemMockWithoutRecipeFiles()
-        project = _project_with_one_plugin('DeathStarBackend')
+        project = _project_with_one_plugin('DeathStarBackend', sources=['plugin.cpp'])
         cmake_recipe = CMakeRecipe(filesystem)
 
         cmake_recipe.generate(project)
@@ -128,12 +128,14 @@ class TestCMakeRecipe(unittest.TestCase):
             'cmake_minimum_required (VERSION 3.7)\n'
             'project(DeathStarBackend)\n'
             'include_directories()\n'
+            'add_library(cest STATIC plugin.cpp)\n'
             'add_executable(DeathStarBackend main.cpp)\n'
+            'target_link_libraries(DeathStarBackend cest)\n'
         )
 
     def test_recipe_generation_with_one_plugin_with_a_package_with_cflags(self):
         filesystem = self.filesystemMockWithoutRecipeFiles()
-        project = _project_with_one_plugin('DeathStarBackend', sources=['plugins.cpp'], cflags=['-DDEFINE'])
+        project = _project_with_one_plugin('DeathStarBackend', sources=['plugin.cpp'], cflags=['-DDEFINE'])
         cmake_recipe = CMakeRecipe(filesystem)
 
         cmake_recipe.generate(project)
@@ -145,8 +147,10 @@ class TestCMakeRecipe(unittest.TestCase):
             'cmake_minimum_required (VERSION 3.7)\n'
             'project(DeathStarBackend)\n'
             'include_directories()\n'
-            'set_source_files_properties(plugins.cpp PROPERTIES COMPILE_FLAGS "-DDEFINE")\n'
+            'add_library(cest STATIC plugin.cpp)\n'
+            'set_source_files_properties(plugin.cpp PROPERTIES COMPILE_FLAGS "-DDEFINE")\n'
             'add_executable(DeathStarBackend main.cpp)\n'
+            'target_link_libraries(DeathStarBackend cest)\n'
         )
 
     def test_recipe_generation_with_one_test_suite(self):
@@ -453,9 +457,8 @@ def _project_with_one_plugin(name, sources=[], cflags=[]):
     project.sources = ['main.cpp']
     plugin = Plugin('cest')
     plugin.add_package(Package('plugins/cest', sources=sources, cflags=cflags))
-    project.add_plugin(Plugin('cest'))
-    for package in plugin.packages:
-        project.add_package(package)
+    plugin.add_sources(sources)
+    project.add_plugin(plugin)
     return project
 
 

--- a/test/domain/test_project_loader.py
+++ b/test/domain/test_project_loader.py
@@ -86,7 +86,7 @@ class TestProjectLoader(unittest.TestCase):
 
         assert Package(path='cpm-hub', cflags=['-std=c++11']) in project.packages
 
-    def test_loading_project_with_with_ldflags(self):
+    def test_loading_project_with_with_libraries_link_option(self):
         yaml_handler = mock.MagicMock()
         filesystem = mock.MagicMock()
         filesystem.find.return_value = []
@@ -101,6 +101,20 @@ class TestProjectLoader(unittest.TestCase):
         project = loader.load()
 
         assert 'pthread' in project.link_options.libraries
+
+    def test_loading_project_with_with_global_compile_flags(self):
+        yaml_handler = mock.MagicMock()
+        filesystem = mock.MagicMock()
+        filesystem.find.return_value = []
+        yaml_handler.load.return_value = {
+            'name': 'Project',
+            'compile_flags': ['-g'],
+        }
+        loader = ProjectLoader(yaml_handler, filesystem)
+
+        project = loader.load()
+
+        assert '-g' in project.compile_flags
 
     def test_loading_project_with_one_target(self):
         yaml_handler = mock.MagicMock()


### PR DESCRIPTION
This pull request allows the user to define project global flags through a new `compile_flags` option in the project descriptor.

This pull request also re-organizes the project compilation, compiling the plugins with sources separately as libraries and then linking the project against them. This way, some possible conflicts when linking c++ projects against c plugins (or viceversa) are removed.