### PR TITLE
Publish pypi package on release

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -27,3 +27,9 @@ jobs:
     - name: Test with pytest
       run: |
         pytest
+    - name: Publish package
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_token }}

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -27,6 +27,11 @@ jobs:
     - name: Test with pytest
       run: |
         pytest
+    - name: Build dist package
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+      run: |
+        pip install pep517
+        python -m pep517.build --source --binary --out-dir dist/ .
     - name: Publish package
       if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@master

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cpm-cli
-version = 0.4
+version = 0.4.1
 description = Chromos Package Manager
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
This pull request sets up the github workflow so that the pypi package is automatically published after a github release is generated. 

Closes #108 