### PR TITLE
Create project from existing sources

### DIFF
--- a/cpm/api/create.py
+++ b/cpm/api/create.py
@@ -10,12 +10,12 @@ from cpm.infrastructure.filesystem import Filesystem
 from cpm.infrastructure.yaml_handler import YamlHandler
 
 
-def new_project(creation_service, project_name, options=CreationOptions()):
-    if creation_service.exists(project_name):
-        return Result(FAIL, f'error: directory {project_name} already exists')
+def new_project(creation_service, options=CreationOptions()):
+    if creation_service.exists(options.directory):
+        return Result(FAIL, f'error: directory {options.directory} already exists')
 
-    creation_service.create(project_name, options)
-    return Result(OK, f'Created project {project_name}')
+    creation_service.create(options)
+    return Result(OK, f'Created project {options.project_name}')
 
 
 def execute(argv):
@@ -33,7 +33,8 @@ def execute(argv):
         generate_sample_code=not args.no_sample_code,
         project_name=args.project_name,
         directory=args.project_name,
+        init_from_existing_sources=False,
     )
-    result = new_project(service, args.project_name, options)
+    result = new_project(service, options)
 
     return result

--- a/cpm/api/create.py
+++ b/cpm/api/create.py
@@ -29,7 +29,11 @@ def execute(argv):
     project_loader = ProjectLoader(yaml_handler, filesystem)
     service = CreationService(filesystem, project_loader)
 
-    options = CreationOptions(generate_sample_code=not args.no_sample_code)
+    options = CreationOptions(
+        generate_sample_code=not args.no_sample_code,
+        project_name=args.project_name,
+        directory=args.project_name,
+    )
     result = new_project(service, args.project_name, options)
 
     return result

--- a/cpm/api/create.py
+++ b/cpm/api/create.py
@@ -9,11 +9,11 @@ from cpm.domain.creation_service import CreationOptions
 from cpm.infrastructure.filesystem import Filesystem
 
 
-def new_project(project_constructor, project_name, options=CreationOptions()):
-    if project_constructor.exists(project_name):
+def new_project(creation_service, project_name, options=CreationOptions()):
+    if creation_service.exists(project_name):
         return Result(FAIL, f'error: directory {project_name} already exists')
 
-    project_constructor.create(project_name, options)
+    creation_service.create(project_name, options)
     return Result(OK, f'Created project {project_name}')
 
 

--- a/cpm/api/init.py
+++ b/cpm/api/init.py
@@ -12,10 +12,11 @@ from cpm.infrastructure.yaml_handler import YamlHandler
 
 def init_project(creation_service, options=CreationOptions(init_from_existing_sources=True)):
     if creation_service.exists(options.directory):
-        return Result(FAIL, f'error: directory {options.directory} already contains a CPM project')
+        directory_print = 'current directory' if options.directory == '.' else f'directory {options.directory}'
+        return Result(FAIL, f'error: {directory_print} already contains a CPM project')
 
     creation_service.create(options)
-    return Result(OK, f'Created project {options.name}')
+    return Result(OK, f'Created project {options.project_name}')
 
 
 def execute(argv):
@@ -32,7 +33,7 @@ def execute(argv):
         init_from_existing_sources=True,
         generate_sample_code=False,
         directory='.',
-        name=args.name
+        project_name=args.project_name
     )
     result = init_project(service, options)
 

--- a/cpm/api/init.py
+++ b/cpm/api/init.py
@@ -11,7 +11,7 @@ from cpm.infrastructure.yaml_handler import YamlHandler
 
 
 def init_project(creation_service, options=CreationOptions(init_from_existing_sources=True)):
-    if creation_service.exists(options):
+    if creation_service.exists(options.directory):
         return Result(FAIL, f'error: directory {options.directory} already contains a CPM project')
 
     creation_service.create(options)
@@ -27,6 +27,13 @@ def execute(argv):
     yaml_handler = YamlHandler(filesystem)
     project_loader = ProjectLoader(yaml_handler, filesystem)
     service = CreationService(filesystem, project_loader)
-    result = init_project(service, args.project_name)
+
+    options = CreationOptions(
+        init_from_existing_sources=True,
+        generate_sample_code=False,
+        directory='.',
+        name=args.name
+    )
+    result = init_project(service, options)
 
     return result

--- a/cpm/api/init.py
+++ b/cpm/api/init.py
@@ -10,26 +10,23 @@ from cpm.infrastructure.filesystem import Filesystem
 from cpm.infrastructure.yaml_handler import YamlHandler
 
 
-def new_project(creation_service, project_name, options=CreationOptions()):
-    if creation_service.exists(project_name):
-        return Result(FAIL, f'error: directory {project_name} already exists')
+def init_project(creation_service, options=CreationOptions(init_from_existing_sources=True)):
+    if creation_service.exists(options):
+        return Result(FAIL, f'error: directory {options.directory} already contains a CPM project')
 
-    creation_service.create(project_name, options)
-    return Result(OK, f'Created project {project_name}')
+    creation_service.create(options)
+    return Result(OK, f'Created project {options.name}')
 
 
 def execute(argv):
-    create_parser = argparse.ArgumentParser(prog='cpm create', description='Chromos Package Manager', add_help=False)
+    create_parser = argparse.ArgumentParser(prog='cpm init', description='Chromos Package Manager', add_help=False)
     create_parser.add_argument('project_name')
-    create_parser.add_argument('-s', '--no-sample-code', required=False, action='store_true', default=False)
     args = create_parser.parse_args(argv)
 
     filesystem = Filesystem()
     yaml_handler = YamlHandler(filesystem)
     project_loader = ProjectLoader(yaml_handler, filesystem)
     service = CreationService(filesystem, project_loader)
-
-    options = CreationOptions(generate_sample_code=not args.no_sample_code)
-    result = new_project(service, args.project_name, options)
+    result = init_project(service, args.project_name)
 
     return result

--- a/cpm/domain/creation_service.py
+++ b/cpm/domain/creation_service.py
@@ -7,7 +7,7 @@ from cpm.domain.sample_code import CPP_HELLO_WORLD
 
 @dataclass
 class CreationOptions:
-    name: str = 'MyProject'
+    project_name: str = 'MyProject'
     directory: str = '.'
     generate_sample_code: bool = True
     init_from_existing_sources: bool = False
@@ -25,10 +25,11 @@ class CreationService:
         except NotAChromosProject:
             return False
 
-    def create(self, project_name, options=CreationOptions()):
-        project = Project(project_name)
-        self.create_project_directory(project_name)
-        self.create_project_descriptor_file(project_name)
+    def create(self, options):
+        project = Project(options.project_name)
+        if not options.init_from_existing_sources:
+            self.create_project_directory(options.directory)
+        self.create_project_descriptor_file(options)
 
         if options.generate_sample_code:
             self.generate_sample_code(project)
@@ -42,10 +43,10 @@ class CreationService:
             CPP_HELLO_WORLD
         )
 
-    def create_project_descriptor_file(self, project_name):
+    def create_project_descriptor_file(self, options):
         self.filesystem.create_file(
-            f'{project_name}/project.yaml',
-            f'name: {project_name}\n'
+            f'{options.directory}/project.yaml',
+            f'name: {options.project_name}\n'
         )
 
     def create_project_directory(self, project_name):

--- a/cpm/domain/creation_service.py
+++ b/cpm/domain/creation_service.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 
 from cpm.domain.project import Project
+from cpm.domain.project_loader import NotAChromosProject
 from cpm.domain.sample_code import CPP_HELLO_WORLD
 
 
@@ -17,8 +18,12 @@ class CreationService:
         self.filesystem = filesystem
         self.project_loader = project_loader
 
-    def exists(self, project_name):
-        return self.filesystem.directory_exists(project_name)
+    def exists(self, directory):
+        try:
+            self.project_loader.load(directory)
+            return True
+        except NotAChromosProject:
+            return False
 
     def create(self, project_name, options=CreationOptions()):
         project = Project(project_name)

--- a/cpm/domain/creation_service.py
+++ b/cpm/domain/creation_service.py
@@ -6,12 +6,16 @@ from cpm.domain.sample_code import CPP_HELLO_WORLD
 
 @dataclass
 class CreationOptions:
+    name: str = 'MyProject'
+    directory: str = '.'
     generate_sample_code: bool = True
+    init_from_existing_sources: bool = False
 
 
 class CreationService:
-    def __init__(self, filesystem):
+    def __init__(self, filesystem, project_loader):
         self.filesystem = filesystem
+        self.project_loader = project_loader
 
     def exists(self, project_name):
         return self.filesystem.directory_exists(project_name)

--- a/cpm/domain/plugin_packager.py
+++ b/cpm/domain/plugin_packager.py
@@ -1,4 +1,4 @@
-from cpm.domain.project import PROJECT_ROOT_FILE
+from cpm.domain.project_loader import PROJECT_DESCRIPTOR_FILE
 
 
 class PluginPackager(object):
@@ -13,7 +13,7 @@ class PluginPackager(object):
             raise PackagingFailure(cause='build directory exists')
 
         self.filesystem.create_directory(build_directory)
-        self.filesystem.copy_file(PROJECT_ROOT_FILE, f'{build_directory}/plugin.yaml')
+        self.filesystem.copy_file(PROJECT_DESCRIPTOR_FILE, f'{build_directory}/plugin.yaml')
         for package in project.packages:
             self.filesystem.copy_directory(package.path, f'{build_directory}/{package.path}')
         self.filesystem.zip(build_directory, f'{project.name}')

--- a/cpm/domain/project.py
+++ b/cpm/domain/project.py
@@ -1,8 +1,6 @@
 from dataclasses import dataclass
 from dataclasses import field
 
-PROJECT_ROOT_FILE = 'project.yaml'
-
 
 @dataclass
 class Target:

--- a/cpm/domain/project_loader.py
+++ b/cpm/domain/project_loader.py
@@ -13,9 +13,9 @@ class ProjectLoader(object):
         self.yaml_handler = yaml_handler
         self.plugin_loader = PluginLoader(yaml_handler, filesystem)
 
-    def load(self):
+    def load(self, directory='.'):
         try:
-            description = self.yaml_handler.load(PROJECT_DESCRIPTOR_FILE)
+            description = self.yaml_handler.load(f'{directory}/{PROJECT_DESCRIPTOR_FILE}')
             project = Project(description['name'])
             project.version = description.get('version', "0.1")
             project.add_sources(['main.cpp'])

--- a/cpm/domain/project_loader.py
+++ b/cpm/domain/project_loader.py
@@ -1,8 +1,10 @@
 from cpm.domain.plugin_loader import PluginLoader
-from cpm.domain.project import PROJECT_ROOT_FILE, ProjectAction
+from cpm.domain.project import ProjectAction
 from cpm.domain.project import Package
 from cpm.domain.project import Project
 from cpm.domain.project import Target
+
+PROJECT_DESCRIPTOR_FILE = 'project.yaml'
 
 
 class ProjectLoader(object):
@@ -13,7 +15,7 @@ class ProjectLoader(object):
 
     def load(self):
         try:
-            description = self.yaml_handler.load(PROJECT_ROOT_FILE)
+            description = self.yaml_handler.load(PROJECT_DESCRIPTOR_FILE)
             project = Project(description['name'])
             project.version = description.get('version', "0.1")
             project.add_sources(['main.cpp'])

--- a/test/api/test_api_create.py
+++ b/test/api/test_api_create.py
@@ -7,28 +7,37 @@ from cpm.domain.creation_service import CreationOptions
 
 class TestApiCreate(unittest.TestCase):
     def test_create_project_uses_creation_service_for_initializing_project(self):
-        project_constructor = mock.MagicMock()
-        project_constructor.exists.return_value = False
+        creation_service = mock.MagicMock()
+        creation_service.exists.return_value = False
+        options = CreationOptions(
+            project_name='Awesome Project'
+        )
 
-        result = new_project(project_constructor, 'Awesome Project')
+        result = new_project(creation_service, options)
 
         assert result.status_code == 0
-        project_constructor.create.assert_called_once_with('Awesome Project', CreationOptions())
+        creation_service.create.assert_called_once_with(options)
 
     def test_returns_error_code_when_project_already_exists(self):
-        project_constructor = mock.MagicMock()
-        project_constructor.exists.return_value = True
+        creation_service = mock.MagicMock()
+        creation_service.exists.return_value = True
+        options = CreationOptions(
+            project_name='Awesome Project'
+        )
 
-        result = new_project(project_constructor, 'Awesome Project')
+        result = new_project(creation_service, options)
 
         assert result.status_code == 1
 
     def test_create_project_accepts_options_from_api(self):
-        project_constructor = mock.MagicMock()
-        project_constructor.exists.return_value = False
-        options = CreationOptions(generate_sample_code=True)
+        creation_service = mock.MagicMock()
+        creation_service.exists.return_value = False
+        options = CreationOptions(
+            project_name='Awesome Project',
+            generate_sample_code=True
+        )
 
-        result = new_project(project_constructor, 'Awesome Project', options)
+        result = new_project(creation_service, options)
 
         assert result.status_code == 0
-        project_constructor.create.assert_called_once_with('Awesome Project', options)
+        creation_service.create.assert_called_once_with(options)

--- a/test/api/test_api_init.py
+++ b/test/api/test_api_init.py
@@ -12,7 +12,7 @@ class TestApiInit(unittest.TestCase):
         options = CreationOptions(
             init_from_existing_sources=True,
             directory='.',
-            name='Awesome Project'
+            project_name='Awesome Project'
         )
 
         result = init_project(creation_service, options)

--- a/test/api/test_api_init.py
+++ b/test/api/test_api_init.py
@@ -1,0 +1,29 @@
+import unittest
+import mock
+
+from cpm.api.init import init_project
+from cpm.domain.creation_service import CreationOptions
+
+
+class TestApiInit(unittest.TestCase):
+    def test_init_project_uses_creation_service_for_initializing_project(self):
+        creation_service = mock.MagicMock()
+        creation_service.exists.return_value = False
+        options = CreationOptions(
+            init_from_existing_sources=True,
+            directory='.',
+            name='Awesome Project'
+        )
+
+        result = init_project(creation_service, options)
+
+        assert result.status_code == 0
+        creation_service.create.assert_called_once_with(options)
+
+    def test_returns_error_code_when_project_already_exists(self):
+        creation_service = mock.MagicMock()
+        creation_service.exists.return_value = True
+
+        result = init_project(creation_service)
+
+        assert result.status_code == 1

--- a/test/domain/test_creation_service.py
+++ b/test/domain/test_creation_service.py
@@ -38,21 +38,48 @@ class TestCreationService(unittest.TestCase):
         filesystem = mock.MagicMock()
         project_loader = mock.MagicMock()
         creation_service = CreationService(filesystem, project_loader)
+        creation_options = CreationOptions(
+            generate_sample_code=False,
+            directory='AwesomeProject',
+            project_name='AwesomeProject'
+        )
 
-        creation_service.create('AwesomeProject', CreationOptions(generate_sample_code=False))
+        creation_service.create(creation_options)
 
         filesystem.create_directory.assert_called_once_with('AwesomeProject')
         filesystem.create_file.assert_called_once_with(
             'AwesomeProject/project.yaml',
             'name: AwesomeProject\n'
         )
-        
+
+    def test_it_only_creates_descriptor_file_when_creating_project_from_existing_sources(self):
+        filesystem = mock.MagicMock()
+        project_loader = mock.MagicMock()
+        creation_service = CreationService(filesystem, project_loader)
+        creation_options = CreationOptions(
+            generate_sample_code=False,
+            directory='.',
+            project_name='AwesomeProject',
+            init_from_existing_sources=True
+        )
+
+        creation_service.create(creation_options)
+
+        filesystem.create_directory.assert_not_called()
+        filesystem.create_file.assert_called_once_with(
+            './project.yaml',
+            'name: AwesomeProject\n'
+        )
     def test_creation_service_generates_default_sample_code_when_selected(self):
         filesystem = mock.MagicMock()
         project_loader = mock.MagicMock()
         creation_service = CreationService(filesystem, project_loader)
+        creation_options = CreationOptions(
+            directory='AwesomeProject',
+            project_name='AwesomeProject'
+        )
 
-        creation_service.create('AwesomeProject')
+        creation_service.create(creation_options)
 
         filesystem.create_file.assert_called_with(
             'AwesomeProject/main.cpp',
@@ -63,8 +90,11 @@ class TestCreationService(unittest.TestCase):
         filesystem = mock.MagicMock()
         project_loader = mock.MagicMock()
         creation_service = CreationService(filesystem, project_loader)
+        creation_options = CreationOptions(
+            project_name='AwesomeProject'
+        )
 
-        project = creation_service.create('AwesomeProject', CreationOptions(generate_sample_code=True))
+        project = creation_service.create(creation_options)
 
         assert project.name == 'AwesomeProject'
         assert project.sources == ['main.cpp']

--- a/test/domain/test_creation_service.py
+++ b/test/domain/test_creation_service.py
@@ -1,26 +1,43 @@
 import unittest
 import mock
 
+from cpm.domain.project import Project
 from cpm.domain.sample_code import CPP_HELLO_WORLD
 from cpm.domain.creation_service import CreationService
 from cpm.domain.creation_service import CreationOptions
+from cpm.domain.project_loader import NotAChromosProject
 
 
 class TestCreationService(unittest.TestCase):
-    def test_project_constructor_instantiation(self):
+    def test_it_instantiation(self):
         filesystem = mock.MagicMock()
-        CreationService(filesystem)
+        project_loader = mock.MagicMock()
+        CreationService(filesystem, project_loader)
 
-    def test_project_constructor_verifies_if_project_exists(self):
+    def test_project_exists_when_loading_the_project_succeeds(self):
         filesystem = mock.MagicMock()
-        filesystem.directory_exists.return_value = True
-        creation_service = CreationService(filesystem)
+        project_loader = mock.MagicMock()
+        project_loader.load.return_value = Project('dummy')
+        creation_service = CreationService(filesystem, project_loader)
+        directory = '.'
 
-        assert creation_service.exists('some project')
+        assert creation_service.exists(directory)
+        project_loader.load.assert_called_once_with(directory)
 
-    def test_project_constructor_creates_directory_and_descriptor_file_when_creating_project(self):
+    def test_project_does_not_exist_when_loading_the_project_fails(self):
         filesystem = mock.MagicMock()
-        creation_service = CreationService(filesystem)
+        project_loader = mock.MagicMock()
+        project_loader.load.side_effect = NotAChromosProject
+        creation_service = CreationService(filesystem, project_loader)
+        directory = 'project_location'
+
+        assert not creation_service.exists(directory)
+        project_loader.load.assert_called_once_with(directory)
+
+    def test_it_creates_directory_and_descriptor_file_when_creating_project(self):
+        filesystem = mock.MagicMock()
+        project_loader = mock.MagicMock()
+        creation_service = CreationService(filesystem, project_loader)
 
         creation_service.create('AwesomeProject', CreationOptions(generate_sample_code=False))
 
@@ -32,7 +49,8 @@ class TestCreationService(unittest.TestCase):
         
     def test_creation_service_generates_default_sample_code_when_selected(self):
         filesystem = mock.MagicMock()
-        creation_service = CreationService(filesystem)
+        project_loader = mock.MagicMock()
+        creation_service = CreationService(filesystem, project_loader)
 
         creation_service.create('AwesomeProject')
 
@@ -43,7 +61,8 @@ class TestCreationService(unittest.TestCase):
 
     def test_creation_service_returns_generated_project(self):
         filesystem = mock.MagicMock()
-        creation_service = CreationService(filesystem)
+        project_loader = mock.MagicMock()
+        creation_service = CreationService(filesystem, project_loader)
 
         project = creation_service.create('AwesomeProject', CreationOptions(generate_sample_code=True))
 

--- a/test/domain/test_project_loader.py
+++ b/test/domain/test_project_loader.py
@@ -4,7 +4,8 @@ import mock
 
 from cpm.domain.plugin import Plugin
 from cpm.domain.project import Package, ProjectAction
-from cpm.domain.project_loader import NotAChromosProject, PROJECT_DESCRIPTOR_FILE
+from cpm.domain.project_loader import NotAChromosProject
+from cpm.domain.project_loader import PROJECT_DESCRIPTOR_FILE
 from cpm.domain.project_loader import ProjectLoader
 
 
@@ -32,7 +33,20 @@ class TestProjectLoader(unittest.TestCase):
 
         loaded_project = loader.load()
 
-        yaml_handler.load.assert_called_once_with(PROJECT_DESCRIPTOR_FILE)
+        yaml_handler.load.assert_called_once_with(f'./{PROJECT_DESCRIPTOR_FILE}')
+        assert loaded_project.name == 'Project'
+
+    def test_loading_project_from_a_different_directory(self):
+        yaml_handler = mock.MagicMock()
+        filesystem = mock.MagicMock()
+        yaml_handler.load.return_value = {
+            'name': 'Project'
+        }
+        loader = ProjectLoader(yaml_handler, filesystem)
+
+        loaded_project = loader.load(directory='Project')
+
+        yaml_handler.load.assert_called_once_with(f'Project/{PROJECT_DESCRIPTOR_FILE}')
         assert loaded_project.name == 'Project'
 
     def test_loading_project_with_specified_version(self):
@@ -46,7 +60,6 @@ class TestProjectLoader(unittest.TestCase):
 
         loaded_project = loader.load()
 
-        yaml_handler.load.assert_called_once_with(PROJECT_DESCRIPTOR_FILE)
         assert loaded_project.name == 'Project'
         assert loaded_project.version == '1.5'
 
@@ -237,7 +250,6 @@ class TestProjectLoader(unittest.TestCase):
 
         loaded_project = loader.load()
 
-        yaml_handler.load.assert_called_once_with(PROJECT_DESCRIPTOR_FILE)
         assert loaded_project.name == 'Project'
         assert loaded_project.actions == [ProjectAction('deploy', 'sudo make me a sandwich')]
 

--- a/test/domain/test_project_loader.py
+++ b/test/domain/test_project_loader.py
@@ -3,9 +3,8 @@ import unittest
 import mock
 
 from cpm.domain.plugin import Plugin
-from cpm.domain.project import PROJECT_ROOT_FILE
 from cpm.domain.project import Package, ProjectAction
-from cpm.domain.project_loader import NotAChromosProject
+from cpm.domain.project_loader import NotAChromosProject, PROJECT_DESCRIPTOR_FILE
 from cpm.domain.project_loader import ProjectLoader
 
 
@@ -33,7 +32,7 @@ class TestProjectLoader(unittest.TestCase):
 
         loaded_project = loader.load()
 
-        yaml_handler.load.assert_called_once_with(PROJECT_ROOT_FILE)
+        yaml_handler.load.assert_called_once_with(PROJECT_DESCRIPTOR_FILE)
         assert loaded_project.name == 'Project'
 
     def test_loading_project_with_specified_version(self):
@@ -47,7 +46,7 @@ class TestProjectLoader(unittest.TestCase):
 
         loaded_project = loader.load()
 
-        yaml_handler.load.assert_called_once_with(PROJECT_ROOT_FILE)
+        yaml_handler.load.assert_called_once_with(PROJECT_DESCRIPTOR_FILE)
         assert loaded_project.name == 'Project'
         assert loaded_project.version == '1.5'
 
@@ -238,7 +237,7 @@ class TestProjectLoader(unittest.TestCase):
 
         loaded_project = loader.load()
 
-        yaml_handler.load.assert_called_once_with(PROJECT_ROOT_FILE)
+        yaml_handler.load.assert_called_once_with(PROJECT_DESCRIPTOR_FILE)
         assert loaded_project.name == 'Project'
         assert loaded_project.actions == [ProjectAction('deploy', 'sudo make me a sandwich')]
 

--- a/test/e2e/API.robot
+++ b/test/e2e/API.robot
@@ -13,8 +13,13 @@ Create-Project
     ${result}=    Run Process    ${CPM}    create    ${PROJECT_NAME}
     Should Be Equal 	${result.rc} 	${0}
 
+Create-New-Project-When-Directory-Exists
+    Run Process    ${CPM}    create    ${PROJECT_NAME}
+    ${result}=    Run Process    ${CPM}    create    ${PROJECT_NAME}
+    Should Be Equal 	${result.rc} 	${1}
+
 Build-With-Sample-Code
-    Run Process    ${CPM}    create    -s    ${PROJECT_NAME}
+    Run Process    ${CPM}    create    ${PROJECT_NAME}
     Run Process    ${CPM}    build    cwd=${PROJECT_NAME}    alias=build
     ${result}=    Get Process Result    build
     Should Be Equal 	${result.rc} 	${0}


### PR DESCRIPTION
This pull request implements the `init` command line api. It allows to initialize the current directory as a CPM project. This makes sense for all those software projects born as git repositories.

The command synopsis is:

```bash
$ cpm init ProjectName
```

The above command will initialize the current directory (`.`) as a CPM project, creating the project descriptor. For now this is the only action taken. The automatic detection of packages is left as an improvement but it might not be feasible (at least without modification of the project sources).

Closes #22 