### PR TITLE
Process and print plugin publication failures

### DIFF
--- a/cpm/api/publish.py
+++ b/cpm/api/publish.py
@@ -9,6 +9,9 @@ from cpm.domain.publish_service import PublishService
 from cpm.domain.plugin_packager import PackagingFailure
 from cpm.domain.project_loader import NotAChromosProject
 from cpm.infrastructure.cpm_hub_connector_v1 import CpmHubConnectorV1
+from cpm.infrastructure.cpm_hub_connector_v1 import InvalidCpmHubUrl
+from cpm.infrastructure.cpm_hub_connector_v1 import AuthenticationFailure
+from cpm.infrastructure.cpm_hub_connector_v1 import PublicationFailure
 from cpm.infrastructure.filesystem import Filesystem
 from cpm.infrastructure.http_client import HttpConnectionError
 from cpm.infrastructure.yaml_handler import YamlHandler
@@ -23,6 +26,12 @@ def publish_project(publish_service):
         return Result(FAIL, f'error: {error.cause}')
     except HttpConnectionError:
         return Result(FAIL, f'error: failed to connect to CPM Hub')
+    except InvalidCpmHubUrl:
+        return Result(FAIL, f'error: invalid CPM Hub URL')
+    except AuthenticationFailure:
+        return Result(FAIL, f'error: invalid credentials')
+    except PublicationFailure:
+        return Result(FAIL, f'error: publish failed')
     except KeyboardInterrupt:
         return Result(FAIL, f'interrupted')
 

--- a/cpm/infrastructure/http_client.py
+++ b/cpm/infrastructure/http_client.py
@@ -13,7 +13,8 @@ class HttpResponse:
 
 def post(url, data=None, headers=None, files=None):
     try:
-        requests.post(url, files=files, data=data, headers=headers, verify=False)
+        response = requests.post(url, files=files, data=data, headers=headers, verify=False)
+        return HttpResponse(response.status_code, response.text)
     except requests.exceptions.ConnectionError as e:
         raise HttpConnectionError()
 

--- a/test/api/test_api_publish.py
+++ b/test/api/test_api_publish.py
@@ -5,6 +5,9 @@ from cpm.domain.plugin_packager import PackagingFailure
 from cpm.domain.project_loader import NotAChromosProject
 from cpm.infrastructure.http_client import HttpConnectionError
 from cpm.api.publish import publish_project
+from cpm.infrastructure.cpm_hub_connector_v1 import AuthenticationFailure
+from cpm.infrastructure.cpm_hub_connector_v1 import InvalidCpmHubUrl
+from cpm.infrastructure.cpm_hub_connector_v1 import PublicationFailure
 
 
 class TestApiPublish(unittest.TestCase):
@@ -29,6 +32,33 @@ class TestApiPublish(unittest.TestCase):
     def test_publish_fails_when_connection_to_server_fails(self):
         publish_service = mock.MagicMock()
         publish_service.publish.side_effect = HttpConnectionError
+
+        result = publish_project(publish_service)
+
+        assert result.status_code == 1
+        publish_service.publish.assert_called_once()
+
+    def test_publish_fails_when_invalid_url_is_specified(self):
+        publish_service = mock.MagicMock()
+        publish_service.publish.side_effect = InvalidCpmHubUrl
+
+        result = publish_project(publish_service)
+
+        assert result.status_code == 1
+        publish_service.publish.assert_called_once()
+
+    def test_publish_fails_when_authentication_fails(self):
+        publish_service = mock.MagicMock()
+        publish_service.publish.side_effect = AuthenticationFailure
+
+        result = publish_project(publish_service)
+
+        assert result.status_code == 1
+        publish_service.publish.assert_called_once()
+
+    def test_publish_fails_when_publication_fails(self):
+        publish_service = mock.MagicMock()
+        publish_service.publish.side_effect = PublicationFailure
 
         result = publish_project(publish_service)
 


### PR DESCRIPTION
With this MR, CPM will display information about the various publication failures, like entering invalid URL, credentials or other errors.

Closes #114 