### PR TITLE
Set infrastructure to allow installation of specific plugin version

### DIFF
--- a/cpm/api/install.py
+++ b/cpm/api/install.py
@@ -15,31 +15,31 @@ from cpm.infrastructure.http_client import HttpConnectionError
 from cpm.infrastructure.yaml_handler import YamlHandler
 
 
-def install_plugin(install_service, plugin):
+def install_plugin(install_service, name, version='latest'):
     try:
-        install_service.install(plugin)
+        install_service.install(name, version)
     except NotAChromosProject:
         return Result(FAIL, 'error: not a Chromos project')
     except PluginNotFound:
-        return Result(FAIL, f'error: plugin {plugin} not found in CPM Hub')
+        return Result(FAIL, f'error: plugin {name} not found in CPM Hub')
     except HttpConnectionError as e:
         return Result(FAIL, f'error: failed to connect to CPM Hub at {e}')
 
-    return Result(OK, f'Installed plugin "{plugin}"')
+    return Result(OK, f'Installed plugin "{name}"')
 
 
 def execute(argv):
     create_parser = argparse.ArgumentParser(prog='cpm install', description='Chromos Package Manager', add_help=False)
-    create_parser.add_argument('plugin_name')
+    create_parser.add_argument('plugin_name', nargs='?')
     args = create_parser.parse_args(argv)
 
     filesystem = Filesystem()
     yaml_handler = YamlHandler(filesystem)
-    user_configuration = CpmUserConfiguration(yaml_handler, filesystem)
-    user_configuration.load()
     project_loader = ProjectLoader(yaml_handler, filesystem)
     plugin_loader = PluginLoader(yaml_handler, filesystem)
     plugin_installer = PluginInstaller(filesystem, plugin_loader)
+    user_configuration = CpmUserConfiguration(yaml_handler, filesystem)
+    user_configuration.load()
     cpm_hub_connector = CpmHubConnectorV1(filesystem, repository_url=f'{user_configuration["cpm_hub_url"]}/plugins')
     service = InstallService(project_loader, plugin_installer, cpm_hub_connector)
 

--- a/cpm/domain/install_service.py
+++ b/cpm/domain/install_service.py
@@ -4,10 +4,10 @@ class InstallService(object):
         self.project_loader = project_loader
         self.plugin_installer = plugin_installer
 
-    def install(self, plugin_name):
+    def install(self, name, version):
         self.project_loader.load()
-        plugin_download = self.cpm_hub_connector.download_plugin(plugin_name)
-        plugin = self.plugin_installer.install(plugin_download)
+        plugin_download = self.cpm_hub_connector.download_plugin(name, version)
+        return self.plugin_installer.install(plugin_download)
 
 
 class PluginNotFound(RuntimeError):

--- a/cpm/infrastructure/cpm_hub_connector_v1.py
+++ b/cpm/infrastructure/cpm_hub_connector_v1.py
@@ -34,8 +34,8 @@ class CpmHubConnectorV1(object):
         if response.status_code != HTTPStatus.OK:
             raise PublicationFailure()
 
-    def download_plugin(self, plugin_name):
-        response = http_client.get(f'{self.repository_url}/{plugin_name}')
+    def download_plugin(self, name, version):
+        response = http_client.get(f'{self.repository_url}/{name}/{version}')
         if response.status_code == HTTPStatus.NOT_FOUND:
             raise PluginNotFound
 

--- a/cpm/infrastructure/cpm_hub_connector_v1.py
+++ b/cpm/infrastructure/cpm_hub_connector_v1.py
@@ -6,7 +6,6 @@ from http import HTTPStatus
 from cpm.domain.install_service import PluginNotFound
 from cpm.domain.plugin_download import PluginDownload
 from cpm.infrastructure import http_client
-from cpm.infrastructure.http_client import HttpConnectionError
 
 
 class CpmHubConnectorV1(object):
@@ -35,12 +34,15 @@ class CpmHubConnectorV1(object):
             raise PublicationFailure()
 
     def download_plugin(self, name, version):
-        response = http_client.get(f'{self.repository_url}/{name}/{version}')
+        response = http_client.get(self.__plugin_url(name, version))
         if response.status_code == HTTPStatus.NOT_FOUND:
-            raise PluginNotFound
+            raise PluginNotFound()
 
         data = json.loads(response.body)
         return PluginDownload(data['plugin_name'], data['version'], data['payload'])
+
+    def __plugin_url(self, name, version):
+        return f'{self.repository_url}/{name}' if version == "latest" else f'{self.repository_url}/{name}/{version}'
 
 
 class AuthenticationFailure(RuntimeError):

--- a/test/api/test_api_install.py
+++ b/test/api/test_api_install.py
@@ -12,35 +12,43 @@ class TestApiInstall(unittest.TestCase):
         install_service = mock.MagicMock()
         install_service.install.side_effect = NotAChromosProject
 
-        result = install_plugin(install_service, "cest")
+        result = install_plugin(install_service, 'cest')
 
         assert result.status_code == 1
-        install_service.install.assert_called_once_with("cest")
+        install_service.install.assert_called_once_with('cest', 'latest')
 
     def test_plugin_install_fails_when_http_connection_fails(self):
         install_service = mock.MagicMock()
         install_service.install.side_effect = HttpConnectionError
 
-        result = install_plugin(install_service, "cest")
+        result = install_plugin(install_service, 'cest')
 
         assert result.status_code == 1
-        install_service.install.assert_called_once_with("cest")
+        install_service.install.assert_called_once_with('cest', 'latest')
 
     def test_plugin_install_fails_when_plugin_is_not_found(self):
         install_service = mock.MagicMock()
         install_service.install.side_effect = PluginNotFound
 
-        result = install_plugin(install_service, "cest")
+        result = install_plugin(install_service, 'cest')
 
         assert result.status_code == 1
-        install_service.install.assert_called_once_with("cest")
+        install_service.install.assert_called_once_with('cest', 'latest')
 
     def test_plugin_install(self):
         install_service = mock.MagicMock()
 
-        result = install_plugin(install_service, "cest")
+        result = install_plugin(install_service, 'cest')
 
         assert result.status_code == 0
-        install_service.install.assert_called_once_with("cest")
+        install_service.install.assert_called_once_with('cest', 'latest')
+
+    def test_plugin_install_of_specific_version(self):
+        install_service = mock.MagicMock()
+
+        result = install_plugin(install_service, 'cest', '1.1')
+
+        assert result.status_code == 0
+        install_service.install.assert_called_once_with('cest', '1.1')
 
 

--- a/test/domain/test_install_service.py
+++ b/test/domain/test_install_service.py
@@ -24,7 +24,7 @@ class TestInstallService(unittest.TestCase):
         project_loader.load.side_effect = NotAChromosProject
         service = InstallService(project_loader, plugin_installer, cpm_hub_connector)
 
-        self.assertRaises(NotAChromosProject, service.install, "cest")
+        self.assertRaises(NotAChromosProject, service.install, 'cest', 'latest')
 
         project_loader.load.assert_called_once()
 
@@ -35,9 +35,9 @@ class TestInstallService(unittest.TestCase):
         cpm_hub_connector.download_plugin.side_effect = AuthenticationFailure
         service = InstallService(project_loader, plugin_installer, cpm_hub_connector)
 
-        self.assertRaises(AuthenticationFailure, service.install, "cest")
+        self.assertRaises(AuthenticationFailure, service.install, 'cest', 'latest')
 
-        cpm_hub_connector.download_plugin.assert_called_once_with("cest")
+        cpm_hub_connector.download_plugin.assert_called_once_with('cest', 'latest')
 
     def test_install_service_fails_when_plugin_is_not_found_in_cpm_hub(self):
         project_loader = MagicMock()
@@ -46,23 +46,38 @@ class TestInstallService(unittest.TestCase):
         cpm_hub_connector.download_plugin.side_effect = PluginNotFound
         service = InstallService(project_loader, plugin_installer, cpm_hub_connector)
 
-        self.assertRaises(PluginNotFound, service.install, "cest")
+        self.assertRaises(PluginNotFound, service.install, 'cest', 'latest')
 
-        cpm_hub_connector.download_plugin.assert_called_once_with("cest")
+        cpm_hub_connector.download_plugin.assert_called_once_with('cest', 'latest')
 
     def test_install_service_downloads_plugin_then_installs_it_and_updates_the_project(self):
         project_loader = MagicMock()
         cpm_hub_connector = MagicMock()
         plugin_installer = MagicMock()
         plugin_download = MagicMock()
-        plugin = Plugin("cest")
-        plugin_installer.install.return_value = plugin
+        plugin_installer.install.return_value = Plugin("cest")
         project = Project("Project")
         project_loader.load.return_value = project
         cpm_hub_connector.download_plugin.return_value = plugin_download
         service = InstallService(project_loader, plugin_installer, cpm_hub_connector)
 
-        service.install("cest")
+        service.install('cest', 'latest')
 
-        cpm_hub_connector.download_plugin.assert_called_once_with("cest")
+        cpm_hub_connector.download_plugin.assert_called_once_with('cest', 'latest')
+        plugin_installer.install.assert_called_once_with(plugin_download)
+
+    def test_it_installs_given_plugin_version(self):
+        project_loader = MagicMock()
+        cpm_hub_connector = MagicMock()
+        plugin_installer = MagicMock()
+        plugin_download = MagicMock()
+        plugin_installer.install.return_value = Plugin("cest")
+        project = Project("Project")
+        project_loader.load.return_value = project
+        cpm_hub_connector.download_plugin.return_value = plugin_download
+        service = InstallService(project_loader, plugin_installer, cpm_hub_connector)
+
+        service.install('cest', '1.0')
+
+        cpm_hub_connector.download_plugin.assert_called_once_with('cest', '1.0')
         plugin_installer.install.assert_called_once_with(plugin_download)

--- a/test/infrastructure/test_cpm_hub_connector_v1.py
+++ b/test/infrastructure/test_cpm_hub_connector_v1.py
@@ -80,10 +80,21 @@ class TestCpmHubConnectorV1(unittest.TestCase):
         connector = CpmHubConnectorV1(filesystem)
         http_client.get.return_value = HttpResponse(HTTPStatus.OK, '{"plugin_name": "cpm-hub", "version": "0.1", "payload": "cGx1Z2luIHBheWxvYWQ="}')
 
-        plugin_download = connector.download_plugin('cest')
+        plugin_download = connector.download_plugin('cest', 'latest')
 
-        http_client.get.assert_called_once_with(f'{connector.repository_url}/cest')
+        http_client.get.assert_called_once_with(f'{connector.repository_url}/cest/latest')
         assert plugin_download == PluginDownload("cpm-hub", "0.1", "cGx1Z2luIHBheWxvYWQ=")
+
+    @patch('cpm.infrastructure.cpm_hub_connector_v1.http_client')
+    def test_download_plugin_gets_plugin_with_specific_version(self, http_client):
+        filesystem = MagicMock()
+        connector = CpmHubConnectorV1(filesystem)
+        http_client.get.return_value = HttpResponse(HTTPStatus.OK, '{"plugin_name": "cpm-hub", "version": "1.0", "payload": "cGx1Z2luIHBheWxvYWQ="}')
+
+        plugin_download = connector.download_plugin('cest', '1.0')
+
+        http_client.get.assert_called_once_with(f'{connector.repository_url}/cest/1.0')
+        assert plugin_download == PluginDownload("cpm-hub", "1.0", "cGx1Z2luIHBheWxvYWQ=")
 
     @patch('cpm.infrastructure.cpm_hub_connector_v1.http_client')
     def test_download_plugin_raises_exception_when_plugin_is_not_found(self, http_client):
@@ -91,6 +102,6 @@ class TestCpmHubConnectorV1(unittest.TestCase):
         connector = CpmHubConnectorV1(filesystem)
         http_client.get.return_value = HttpResponse(HTTPStatus.NOT_FOUND, '')
 
-        self.assertRaises(PluginNotFound, connector.download_plugin, 'cest')
+        self.assertRaises(PluginNotFound, connector.download_plugin, 'cest', 'latest')
 
-        http_client.get.assert_called_once_with(f'{connector.repository_url}/cest')
+        http_client.get.assert_called_once_with(f'{connector.repository_url}/cest/latest')

--- a/test/infrastructure/test_cpm_hub_connector_v1.py
+++ b/test/infrastructure/test_cpm_hub_connector_v1.py
@@ -82,7 +82,7 @@ class TestCpmHubConnectorV1(unittest.TestCase):
 
         plugin_download = connector.download_plugin('cest', 'latest')
 
-        http_client.get.assert_called_once_with(f'{connector.repository_url}/cest/latest')
+        http_client.get.assert_called_once_with(f'{connector.repository_url}/cest')
         assert plugin_download == PluginDownload("cpm-hub", "0.1", "cGx1Z2luIHBheWxvYWQ=")
 
     @patch('cpm.infrastructure.cpm_hub_connector_v1.http_client')
@@ -104,4 +104,4 @@ class TestCpmHubConnectorV1(unittest.TestCase):
 
         self.assertRaises(PluginNotFound, connector.download_plugin, 'cest', 'latest')
 
-        http_client.get.assert_called_once_with(f'{connector.repository_url}/cest/latest')
+        http_client.get.assert_called_once_with(f'{connector.repository_url}/cest')


### PR DESCRIPTION
This pull request sets up the infrastructure to download specific plugin versions from CPM Hub. For the time being, it will only download the latest version of the plugin until the CLI interface is properly defined.

Part of #117 