### PR TITLE
Allow user installing all declared plugins in project descriptor

### DIFF
--- a/cpm/api/update.py
+++ b/cpm/api/update.py
@@ -21,8 +21,8 @@ def update_project(build_service, recipe):
 def execute(argv):
     filesystem = Filesystem()
     yaml_handler = YamlHandler(filesystem)
-    loader = ProjectLoader(yaml_handler, filesystem)
-    service = BuildService(loader)
+    project_loader = ProjectLoader(yaml_handler, filesystem)
+    service = BuildService(project_loader)
     recipe = CMakeRecipe(filesystem)
 
     result = update_project(service, recipe)

--- a/cpm/domain/install_service.py
+++ b/cpm/domain/install_service.py
@@ -6,8 +6,14 @@ class InstallService(object):
 
     def install(self, name, version):
         self.project_loader.load()
+        print(f'installing {name}:{version}')
         plugin_download = self.cpm_hub_connector.download_plugin(name, version)
         return self.plugin_installer.install(plugin_download)
+
+    def install_project_plugins(self):
+        project = self.project_loader.load()
+        for plugin_name, version in project.declared_plugins.items():
+            self.install(plugin_name, version)
 
 
 class PluginNotFound(RuntimeError):

--- a/cpm/domain/project.py
+++ b/cpm/domain/project.py
@@ -32,6 +32,7 @@ class Project(object):
         self.name = name
         self.version = "0.1"
         self.tests = []
+        self.declared_plugins = {}
         self.plugins = []
         self.sources = []
         self.packages = []

--- a/cpm/domain/project_loader.py
+++ b/cpm/domain/project_loader.py
@@ -19,6 +19,7 @@ class ProjectLoader(object):
             project = Project(description['name'])
             project.version = description.get('version', "0.1")
             project.add_sources(['main.cpp'])
+            project.declared_plugins = description.get('plugins', {})
             for package in self.project_packages(description):
                 project.add_package(package)
                 project.add_include_directory(self.filesystem.parent_directory(package.path))

--- a/cpm/infrastructure/cpm_hub_connector_v1.py
+++ b/cpm/infrastructure/cpm_hub_connector_v1.py
@@ -36,7 +36,7 @@ class CpmHubConnectorV1(object):
     def download_plugin(self, name, version):
         response = http_client.get(self.__plugin_url(name, version))
         if response.status_code == HTTPStatus.NOT_FOUND:
-            raise PluginNotFound()
+            raise PluginNotFound(f'{name}:{version}')
 
         data = json.loads(response.body)
         return PluginDownload(data['plugin_name'], data['version'], data['payload'])

--- a/test/api/test_api_install.py
+++ b/test/api/test_api_install.py
@@ -2,6 +2,9 @@ import unittest
 import mock
 
 from cpm.api.install import install_plugin
+from cpm.api.install import install_project_plugins
+from cpm.api.result import OK
+from cpm.api.result import FAIL
 from cpm.domain.install_service import PluginNotFound
 from cpm.domain.project_loader import NotAChromosProject
 from cpm.infrastructure.http_client import HttpConnectionError
@@ -14,7 +17,7 @@ class TestApiInstall(unittest.TestCase):
 
         result = install_plugin(install_service, 'cest')
 
-        assert result.status_code == 1
+        assert result.status_code == FAIL
         install_service.install.assert_called_once_with('cest', 'latest')
 
     def test_plugin_install_fails_when_http_connection_fails(self):
@@ -23,7 +26,7 @@ class TestApiInstall(unittest.TestCase):
 
         result = install_plugin(install_service, 'cest')
 
-        assert result.status_code == 1
+        assert result.status_code == FAIL
         install_service.install.assert_called_once_with('cest', 'latest')
 
     def test_plugin_install_fails_when_plugin_is_not_found(self):
@@ -32,7 +35,7 @@ class TestApiInstall(unittest.TestCase):
 
         result = install_plugin(install_service, 'cest')
 
-        assert result.status_code == 1
+        assert result.status_code == FAIL
         install_service.install.assert_called_once_with('cest', 'latest')
 
     def test_plugin_install(self):
@@ -40,7 +43,7 @@ class TestApiInstall(unittest.TestCase):
 
         result = install_plugin(install_service, 'cest')
 
-        assert result.status_code == 0
+        assert result.status_code == OK
         install_service.install.assert_called_once_with('cest', 'latest')
 
     def test_plugin_install_of_specific_version(self):
@@ -48,7 +51,39 @@ class TestApiInstall(unittest.TestCase):
 
         result = install_plugin(install_service, 'cest', '1.1')
 
-        assert result.status_code == 0
+        assert result.status_code == OK
         install_service.install.assert_called_once_with('cest', '1.1')
+
+    def test_plugin_install_of_all_plugins_in_project(self):
+        install_service = mock.MagicMock()
+
+        result = install_project_plugins(install_service)
+
+        assert result.status_code == OK
+        install_service.install_project_plugins.assert_called_once()
+
+    def test_plugin_install_of_all_plugins_in_project_fails_when_current_directory_is_not_a_chromos_project(self):
+        install_service = mock.MagicMock()
+        install_service.install_project_plugins.side_effect = NotAChromosProject
+
+        result = install_project_plugins(install_service)
+
+        assert result.status_code == FAIL
+
+    def test_plugin_install_of_all_plugins_in_project_fails_when_http_connection_fails(self):
+        install_service = mock.MagicMock()
+        install_service.install_project_plugins.side_effect = HttpConnectionError
+
+        result = install_project_plugins(install_service)
+
+        assert result.status_code == FAIL
+
+    def test_plugin_install_of_all_plugins_in_project_fails_when_one_plugin_does_not_exist(self):
+        install_service = mock.MagicMock()
+        install_service.install_project_plugins.side_effect = PluginNotFound
+
+        result = install_project_plugins(install_service)
+
+        assert result.status_code == FAIL
 
 

--- a/test/domain/test_install_service.py
+++ b/test/domain/test_install_service.py
@@ -1,6 +1,7 @@
 import unittest
 
 from mock import MagicMock
+from mock import call
 
 from cpm.domain.install_service import InstallService
 from cpm.domain.install_service import PluginNotFound
@@ -55,8 +56,8 @@ class TestInstallService(unittest.TestCase):
         cpm_hub_connector = MagicMock()
         plugin_installer = MagicMock()
         plugin_download = MagicMock()
-        plugin_installer.install.return_value = Plugin("cest")
-        project = Project("Project")
+        plugin_installer.install.return_value = Plugin('cest')
+        project = Project('Project')
         project_loader.load.return_value = project
         cpm_hub_connector.download_plugin.return_value = plugin_download
         service = InstallService(project_loader, plugin_installer, cpm_hub_connector)
@@ -71,8 +72,8 @@ class TestInstallService(unittest.TestCase):
         cpm_hub_connector = MagicMock()
         plugin_installer = MagicMock()
         plugin_download = MagicMock()
-        plugin_installer.install.return_value = Plugin("cest")
-        project = Project("Project")
+        plugin_installer.install.return_value = Plugin('cest')
+        project = Project('Project')
         project_loader.load.return_value = project
         cpm_hub_connector.download_plugin.return_value = plugin_download
         service = InstallService(project_loader, plugin_installer, cpm_hub_connector)
@@ -81,3 +82,28 @@ class TestInstallService(unittest.TestCase):
 
         cpm_hub_connector.download_plugin.assert_called_once_with('cest', '1.0')
         plugin_installer.install.assert_called_once_with(plugin_download)
+
+    def test_it_installs_all_plugins_declared_in_project(self):
+        project_loader = MagicMock()
+        cpm_hub_connector = MagicMock()
+        plugin_installer = MagicMock()
+        plugin_download = MagicMock()
+        project = Project('Project')
+        project.declared_plugins = {
+            'cest': '1.0',
+            'fakeit': '1.0',
+        }
+        project_loader.load.return_value = project
+        cpm_hub_connector.download_plugin.return_value = plugin_download
+        service = InstallService(project_loader, plugin_installer, cpm_hub_connector)
+
+        service.install_project_plugins()
+
+        cpm_hub_connector.download_plugin.assert_has_calls([
+            call('cest', '1.0'),
+            call('fakeit', '1.0'),
+        ])
+        plugin_installer.install.assert_has_calls([
+            call(plugin_download),
+            call(plugin_download)
+        ])

--- a/test/domain/test_project_loader.py
+++ b/test/domain/test_project_loader.py
@@ -63,6 +63,24 @@ class TestProjectLoader(unittest.TestCase):
         assert loaded_project.name == 'Project'
         assert loaded_project.version == '1.5'
 
+    def test_loading_project_with_one_declared_plugin(self):
+        yaml_handler = mock.MagicMock()
+        filesystem = mock.MagicMock()
+        yaml_handler.load.return_value = {
+            'name': 'Project',
+            'plugins': {
+                'cest': '1.0'
+            }
+        }
+        loader = ProjectLoader(yaml_handler, filesystem)
+
+        loaded_project = loader.load()
+
+        assert loaded_project.name == 'Project'
+        assert loaded_project.declared_plugins == {
+            'cest': '1.0'
+        }
+
     def test_loading_project_with_one_package(self):
         yaml_handler = mock.MagicMock()
         filesystem = mock.MagicMock()


### PR DESCRIPTION
With this pull request, CPM will install all declared plugins in the project descriptor when the user passes no argument to the command line:

```
$ cpm install
```

Closes #88 