### PR TITLE
Do not re-install up to date bits

### DIFF
--- a/cpm/domain/bit.py
+++ b/cpm/domain/bit.py
@@ -1,13 +1,13 @@
 class Bit(object):
-    def __init__(self, name):
+    def __init__(self, name, version=''):
         self.name = name
-        self.version = ""
+        self.version = version
         self.sources = []
         self.packages = []
         self.include_directories = []
 
     def __eq__(self, other):
-        return self.name == other.name
+        return self.name == other.name and self.version == other.version
 
     def add_include_directory(self, directory):
         self.include_directories.append(directory)

--- a/cpm/domain/install_service.py
+++ b/cpm/domain/install_service.py
@@ -1,3 +1,6 @@
+from cpm.domain.bit import Bit
+
+
 class InstallService(object):
     def __init__(self, project_loader, bit_installer, cpm_hub_connector):
         self.cpm_hub_connector = cpm_hub_connector
@@ -5,7 +8,10 @@ class InstallService(object):
         self.bit_installer = bit_installer
 
     def install(self, name, version):
-        self.project_loader.load()
+        project = self.project_loader.load()
+        if Bit(name, version) in project.bits:
+            print(f'bit already installed: {name}:{version}')
+            return
         print(f'installing {name}:{version}')
         bit_download = self.cpm_hub_connector.download_bit(name, version)
         return self.bit_installer.install(bit_download)

--- a/test/domain/test_install_service.py
+++ b/test/domain/test_install_service.py
@@ -107,3 +107,16 @@ class TestInstallService(unittest.TestCase):
             call(bit_download),
             call(bit_download)
         ])
+
+    def test_it_does_not_install_bit_that_is_already_installed(self):
+        project_loader = MagicMock()
+        cpm_hub_connector = MagicMock()
+        bit_installer = MagicMock()
+        project = Project('Project')
+        project.add_bit(Bit('cest', '1.0'))
+        project_loader.load.return_value = project
+        service = InstallService(project_loader, bit_installer, cpm_hub_connector)
+
+        service.install('cest', '1.0')
+
+        cpm_hub_connector.download_bit.assert_not_called()


### PR DESCRIPTION
With this PR bits that are up to date will not be installed again unless using the latest version:

```
$ cpm install
bit already installed: cest:1.0
bit already installed: mongoose:6.16
bit already installed: json:3.7.3
bit already installed: fakeit:2.0.5
bit already installed: base64:1.0
bit already installed: blake3:1.0
bit already installed: inih:1.0
CPM: Installed bits
```

Closes #131 