### PR TITLE
Install bit transitive dependencies

### DIFF
--- a/cpm/domain/bit.py
+++ b/cpm/domain/bit.py
@@ -5,6 +5,7 @@ class Bit(object):
         self.sources = []
         self.packages = []
         self.include_directories = []
+        self.declared_bits = {}
 
     def __eq__(self, other):
         return self.name == other.name and self.version == other.version

--- a/cpm/domain/bit_loader.py
+++ b/cpm/domain/bit_loader.py
@@ -14,6 +14,7 @@ class BitLoader(object):
         description = self.yaml_handler.load(f'{directory}/bit.yaml')
         bit = Bit(description['name'])
         bit.version = description.get('version', "0.1")
+        bit.declared_bits = description.get('bits', {})
         for package in self.bit_packages(description, directory):
             bit.add_package(package)
             bit.add_include_directory(self.filesystem.parent_directory(package.path))

--- a/cpm/domain/install_service.py
+++ b/cpm/domain/install_service.py
@@ -14,7 +14,9 @@ class InstallService(object):
             return
         self._log_install_or_upgrade(project, name, version)
         bit_download = self.cpm_hub_connector.download_bit(name, version)
-        return self.bit_installer.install(bit_download)
+        bit = self.bit_installer.install(bit_download)
+        for bit_name, version in bit.declared_bits.items():
+            self.install(bit_name, version)
 
     def _log_install_or_upgrade(self, project, name, version):
         installed_bit = next((bit for bit in project.bits if bit.name == name), None)

--- a/test/domain/test_bit_loader.py
+++ b/test/domain/test_bit_loader.py
@@ -55,6 +55,25 @@ class TestBitLoader(unittest.TestCase):
         assert bit.name == 'cest'
         assert bit.include_directories == []
 
+    def test_loading_bit_with_transitive_dependencies(self):
+        filesystem = MagicMock()
+        yaml_handler = MagicMock()
+        yaml_handler.load.return_value = {
+            'name': 'cest',
+            'bits': {
+                'cest': '1.0'
+            }
+        }
+        loader = BitLoader(yaml_handler, filesystem)
+
+        bit = loader.load_from('bits/cest')
+
+        yaml_handler.load.assert_called_once_with('bits/cest/bit.yaml')
+        assert bit.name == 'cest'
+        assert bit.declared_bits == {
+            'cest': '1.0'
+        }
+
     def test_loading_bit_with_one_package(self):
         yaml_handler = MagicMock()
         filesystem = MagicMock()


### PR DESCRIPTION
With this pull request, when bits are installed in the project, the dependencies will be followed greedily, so that any transitive dependencies will be installed as well.

Part of #33 