### PR TITLE
Do not install test bits transitively

### DIFF
--- a/cpm/domain/install_service.py
+++ b/cpm/domain/install_service.py
@@ -21,16 +21,15 @@ class InstallService(object):
     def _log_install_or_upgrade(self, project, name, version):
         installed_bit = next((bit for bit in project.bits if bit.name == name), None)
         if installed_bit:
-            if installed_bit.version < version:
-                print(f'upgrading {name}:{installed_bit.version} -> {version}')
-            else:
-                print(f'downgrading {name}:{installed_bit.version} -> {version}')
+            print(f'{"upgrading" if installed_bit.version < version else "downgrading"} {name}:{installed_bit.version} -> {version}')
         else:
             print(f'installing {name}:{version}')
 
     def install_project_bits(self):
         project = self.project_loader.load()
         for bit_name, version in project.declared_bits.items():
+            self.install(bit_name, version)
+        for bit_name, version in project.declared_test_bits.items():
             self.install(bit_name, version)
 
 

--- a/cpm/domain/project.py
+++ b/cpm/domain/project.py
@@ -33,6 +33,7 @@ class Project(object):
         self.version = "0.1"
         self.tests = []
         self.declared_bits = {}
+        self.declared_test_bits = {}
         self.bits = []
         self.sources = []
         self.packages = []

--- a/cpm/domain/project_loader.py
+++ b/cpm/domain/project_loader.py
@@ -20,6 +20,7 @@ class ProjectLoader(object):
             project.version = description.get('version', "0.1")
             project.add_sources(['main.cpp'])
             project.declared_bits = description.get('bits', {})
+            project.declared_test_bits = description.get('test_bits', {})
             for package in self.project_packages(description):
                 project.add_package(package)
                 project.add_include_directory(self.filesystem.parent_directory(package.path))

--- a/test/domain/test_install_service.py
+++ b/test/domain/test_install_service.py
@@ -104,6 +104,27 @@ class TestInstallService(unittest.TestCase):
             call('fakeit', '1.0'),
         ])
 
+    def test_it_installs_test_bits_declared_in_project(self):
+        project_loader = MagicMock()
+        cpm_hub_connector = MagicMock()
+        bit_installer = MagicMock()
+        bit_download = MagicMock()
+        project = Project('Project')
+        project.declared_test_bits = {
+            'cest': '1.0',
+            'fakeit': '1.0',
+        }
+        project_loader.load.return_value = project
+        cpm_hub_connector.download_bit.return_value = bit_download
+        service = InstallService(project_loader, bit_installer, cpm_hub_connector)
+
+        service.install_project_bits()
+
+        cpm_hub_connector.download_bit.assert_has_calls([
+            call('cest', '1.0'),
+            call('fakeit', '1.0'),
+        ])
+
     def test_it_does_not_install_bit_that_is_already_installed(self):
         project_loader = MagicMock()
         cpm_hub_connector = MagicMock()
@@ -130,7 +151,7 @@ class TestInstallService(unittest.TestCase):
 
         cpm_hub_connector.download_bit.assert_called_once_with('cest', '1.1')
 
-    def test_it_installs_bit_transitive_depdencies(self):
+    def test_it_installs_bit_transitive_dependencies(self):
         project_loader = MagicMock()
         cpm_hub_connector = MagicMock()
         bit_installer = MagicMock()

--- a/test/domain/test_project_loader.py
+++ b/test/domain/test_project_loader.py
@@ -81,6 +81,24 @@ class TestProjectLoader(unittest.TestCase):
             'cest': '1.0'
         }
 
+    def test_loading_project_with_one_declared_test_bit(self):
+        yaml_handler = mock.MagicMock()
+        filesystem = mock.MagicMock()
+        yaml_handler.load.return_value = {
+            'name': 'Project',
+            'test_bits': {
+                'cest': '1.0'
+            }
+        }
+        loader = ProjectLoader(yaml_handler, filesystem)
+
+        loaded_project = loader.load()
+
+        assert loaded_project.name == 'Project'
+        assert loaded_project.declared_test_bits == {
+            'cest': '1.0'
+        }
+
     def test_loading_project_with_one_package(self):
         yaml_handler = mock.MagicMock()
         filesystem = mock.MagicMock()


### PR DESCRIPTION
This pull request introduces the concept of `test bit`, that is, bits that are only used in the tests. This avoids installing transitively test bits.

Closes #33 