### PR TITLE
Resolve "Bits are not linked in tests when link_options.libraries is empty in project descriptor"

### DIFF
--- a/cpm/domain/cmake_recipe.py
+++ b/cpm/domain/cmake_recipe.py
@@ -43,7 +43,6 @@ class CMakeRecipe(object):
 
     def __generate_test_rules(self, cmake_builder, project):
         self.test_executables = [test_file.split('/')[-1].split('.')[0] for test_file in project.tests]
-
         if self.test_executables:
             sources_without_main = self._sources_without_main(project)
             if sources_without_main:
@@ -56,8 +55,8 @@ class CMakeRecipe(object):
                 cmake_builder.add_executable(executable, [test_file], object_libraries) \
                     .set_target_properties(executable, 'COMPILE_FLAGS', ['-std=c++11', '-g'])
                 bits_with_sources = list(filter(lambda p: p.sources, project.bits))
-                if project.link_options.libraries:
-                    link_libraries = [bit.name for bit in bits_with_sources] + project.link_options.libraries
+                link_libraries = [bit.name for bit in bits_with_sources] + project.link_options.libraries
+                if link_libraries:
                     cmake_builder.target_link_libraries(executable, link_libraries)
             cmake_builder.add_custom_target('test', 'echo "> Done', self.test_executables)
 

--- a/test/domain/test_cmake_recipe.py
+++ b/test/domain/test_cmake_recipe.py
@@ -237,6 +237,33 @@ class TestCMakeRecipe(unittest.TestCase):
             ')\n'
         )
 
+    def test_recipe_generation_with_one_test_suite_and_one_bit_and_no_link_libraries(self):
+        filesystem = self.filesystemMockWithoutRecipeFiles()
+        project = _project_with_one_bit('DeathStarBackend', ['bit.cpp'])
+        project.tests = ['tests/test_suite.cpp']
+        cmake_recipe = CMakeRecipe(filesystem)
+
+        cmake_recipe.generate(project)
+
+        filesystem.create_directory.assert_called_once_with('build')
+        filesystem.create_file.assert_called_once_with(
+            'CMakeLists.txt',
+
+            'cmake_minimum_required (VERSION 3.7)\n'
+            'project(DeathStarBackend)\n'
+            'include_directories()\n'
+            'add_library(cest STATIC bit.cpp)\n'
+            'add_executable(DeathStarBackend main.cpp)\n'
+            'target_link_libraries(DeathStarBackend cest)\n'
+            'add_executable(test_suite tests/test_suite.cpp)\n'
+            'set_target_properties(test_suite PROPERTIES COMPILE_FLAGS "-std=c++11 -g")\n'
+            'target_link_libraries(test_suite cest)\n'
+            'add_custom_target(test\n'
+            '    COMMAND echo "> Done"\n'
+            '    DEPENDS test_suite\n'
+            ')\n'
+        )
+
     def test_recipe_generation_with_one_test_suite_and_one_bit_and_link_libraries(self):
         filesystem = self.filesystemMockWithoutRecipeFiles()
         project = _project_with_one_bit('DeathStarBackend', ['bit.cpp'])


### PR DESCRIPTION
Closes #144.