### PR TITLE
Allow defining test only packages

### DIFF
--- a/cpm/domain/cmake_builder.py
+++ b/cpm/domain/cmake_builder.py
@@ -47,6 +47,10 @@ class CMakeBuilder(object):
         self.contents += f'target_link_libraries({target} {" ".join(libraries)})\n'
         return self
 
+    def target_include_directories(self, target, directories):
+        self.contents += f'target_include_directories({target} PUBLIC {" ".join(directories)})\n'
+        return self
+
     def add_custom_target(self, target, command, depends):
         self.contents += f'add_custom_target({target}\n' \
                          f'    COMMAND {command}"\n' \

--- a/cpm/domain/cmake_recipe.py
+++ b/cpm/domain/cmake_recipe.py
@@ -52,12 +52,14 @@ class CMakeRecipe(object):
             else:
                 object_libraries = []
             for executable, test_file in zip(self.test_executables, project.tests):
-                builder.add_executable(executable, [test_file], object_libraries) \
+                builder.add_executable(executable, [test_file] + project.test_sources, object_libraries) \
                     .set_target_properties(executable, 'COMPILE_FLAGS', ['-std=c++11', '-g'])
                 bits_with_sources = list(filter(lambda p: p.sources, project.bits))
                 link_libraries = [bit.name for bit in bits_with_sources] + project.link_options.libraries
                 if link_libraries:
                     builder.target_link_libraries(executable, link_libraries)
+                if project.test_include_directories:
+                    builder.target_include_directories(executable, project.test_include_directories)
             builder.add_custom_target('tests', 'echo "> Done', self.test_executables)
 
     def __generate_build_rules(self, builder, project):

--- a/cpm/domain/project.py
+++ b/cpm/domain/project.py
@@ -42,6 +42,9 @@ class Project(object):
         self.link_options = LinkOptions()
         self.actions = []
         self.targets = {}
+        self.test_packages = []
+        self.test_include_directories = []
+        self.test_sources = []
 
     def add_target(self, target):
         self.targets[target.name] = target
@@ -60,6 +63,15 @@ class Project(object):
 
     def add_include_directory(self, directory):
         self.include_directories.append(directory)
+
+    def add_test_package(self, package):
+        self.test_packages.append(package)
+
+    def add_test_include_directory(self, directory):
+        self.test_include_directories.append(directory)
+
+    def add_test_sources(self, sources):
+        self.test_sources.extend(sources)
 
     def add_library(self, library):
         self.link_options.libraries.append(library)

--- a/cpm/domain/project_loader.py
+++ b/cpm/domain/project_loader.py
@@ -26,6 +26,10 @@ class ProjectLoader(object):
                 project.add_package(package)
                 project.add_include_directory(self.filesystem.parent_directory(package.path))
                 project.add_sources(package.sources)
+            for package in self.project_test_packages(description):
+                project.add_test_package(package)
+                project.add_test_include_directory(self.filesystem.parent_directory(package.path))
+                project.add_test_sources(package.sources)
             project.add_tests(self.test_suites())
             for target in self.described_targets(description):
                 project.add_target(target)
@@ -61,6 +65,11 @@ class ProjectLoader(object):
     def project_packages(self, description):
         for package in description.get('packages', []):
             yield self.load_package(package, description['packages'][package])
+        return []
+
+    def project_test_packages(self, description):
+        for package in description.get('test_packages', []):
+            yield self.load_package(package, description['test_packages'][package])
         return []
 
     def load_package(self, package, package_description):

--- a/test/domain/test_cmake_recipe.py
+++ b/test/domain/test_cmake_recipe.py
@@ -372,6 +372,59 @@ class TestCMakeRecipe(unittest.TestCase):
             ')\n'
         )
 
+    def test_recipe_generation_with_one_test_suite_and_test_include_directories(self):
+        filesystem = self.filesystemMockWithoutRecipeFiles()
+        project = _project_with_sources('DeathStarBackend', ['source.cpp'])
+        project.test_include_directories = ['mocks', 'fakes']
+        project.tests = ['tests/test_suite.cpp']
+        cmake_recipe = CMakeRecipe(filesystem)
+
+        cmake_recipe.generate(project)
+
+        filesystem.create_directory.assert_called_once_with('build')
+        filesystem.create_file.assert_called_once_with(
+            'CMakeLists.txt',
+
+            'cmake_minimum_required (VERSION 3.7)\n'
+            'project(DeathStarBackend)\n'
+            'include_directories()\n'
+            'add_executable(DeathStarBackend main.cpp source.cpp)\n'
+            'add_library(DeathStarBackend_object_library OBJECT source.cpp)\n'
+            'add_executable(test_suite tests/test_suite.cpp $<TARGET_OBJECTS:DeathStarBackend_object_library>)\n'
+            'set_target_properties(test_suite PROPERTIES COMPILE_FLAGS "-std=c++11 -g")\n'
+            'target_include_directories(test_suite PUBLIC mocks fakes)\n'
+            'add_custom_target(tests\n'
+            '    COMMAND echo "> Done"\n'
+            '    DEPENDS test_suite\n'
+            ')\n'
+        )
+
+    def test_recipe_generation_with_one_test_suite_and_test_sources(self):
+        filesystem = self.filesystemMockWithoutRecipeFiles()
+        project = _project_with_sources('DeathStarBackend', ['source.cpp'])
+        project.test_sources = ['mocks/mock.cpp', 'mocks/fake.cpp']
+        project.tests = ['tests/test_suite.cpp']
+        cmake_recipe = CMakeRecipe(filesystem)
+
+        cmake_recipe.generate(project)
+
+        filesystem.create_directory.assert_called_once_with('build')
+        filesystem.create_file.assert_called_once_with(
+            'CMakeLists.txt',
+
+            'cmake_minimum_required (VERSION 3.7)\n'
+            'project(DeathStarBackend)\n'
+            'include_directories()\n'
+            'add_executable(DeathStarBackend main.cpp source.cpp)\n'
+            'add_library(DeathStarBackend_object_library OBJECT source.cpp)\n'
+            'add_executable(test_suite tests/test_suite.cpp mocks/mock.cpp mocks/fake.cpp $<TARGET_OBJECTS:DeathStarBackend_object_library>)\n'
+            'set_target_properties(test_suite PROPERTIES COMPILE_FLAGS "-std=c++11 -g")\n'
+            'add_custom_target(tests\n'
+            '    COMMAND echo "> Done"\n'
+            '    DEPENDS test_suite\n'
+            ')\n'
+        )
+
     def test_recipe_is_updated_when_recipe_files_are_found(self):
         filesystem = self.filesystemMockWithRecipeFiles()
         project = _project_without_sources('DeathStarBackend')

--- a/test/domain/test_project_loader.py
+++ b/test/domain/test_project_loader.py
@@ -289,3 +289,20 @@ class TestProjectLoader(unittest.TestCase):
 
         assert loaded_project.name == 'Project'
         assert loaded_project.actions == [ProjectAction('deploy', 'sudo make me a sandwich')]
+
+    def test_loading_project_with_one_test_package(self):
+        yaml_handler = mock.MagicMock()
+        filesystem = mock.MagicMock()
+        filesystem.find.return_value = []
+        filesystem.parent_directory.return_value = '.'
+        yaml_handler.load.return_value = {
+            'name': 'Project',
+            'test_packages': {'mocks': None},
+        }
+        loader = ProjectLoader(yaml_handler, filesystem)
+
+        project = loader.load()
+
+        assert project.name == 'Project'
+        assert Package(path='mocks') in project.test_packages
+        assert project.test_include_directories == ['.']


### PR DESCRIPTION
With this pull request the user will be able to defined test-only packages, that is, packages that are included only for testing. For example, if you want to include a package with mocks, CPM will include the files and the include directories only for the test targets:

```yaml
test_packages:
    tests/mocks:
```

Closes #79 