### PR TITLE
Allow users to define the compilation configuration for testing only

### DIFF
--- a/cpm/domain/bit_packager.py
+++ b/cpm/domain/bit_packager.py
@@ -6,7 +6,7 @@ class BitPackager(object):
         self.filesystem = filesystem
 
     def pack(self, project, build_directory):
-        if not project.packages:
+        if not project.build.packages:
             raise PackagingFailure(cause='project contains no packages')
 
         if self.filesystem.directory_exists(build_directory):
@@ -14,7 +14,7 @@ class BitPackager(object):
 
         self.filesystem.create_directory(build_directory)
         self.filesystem.copy_file(PROJECT_DESCRIPTOR_FILE, f'{build_directory}/bit.yaml')
-        for package in project.packages:
+        for package in project.build.packages:
             self.filesystem.copy_directory(package.path, f'{build_directory}/{package.path}')
         self.filesystem.zip(build_directory, f'{project.name}')
         self.filesystem.remove_directory(build_directory)

--- a/cpm/domain/creation_service.py
+++ b/cpm/domain/creation_service.py
@@ -37,7 +37,7 @@ class CreationService:
         return project
 
     def generate_sample_code(self, project):
-        project.add_sources(['main.cpp'])
+        project.build.add_sources(['main.cpp'])
         self.filesystem.create_file(
             f'{project.name}/main.cpp',
             CPP_HELLO_WORLD

--- a/cpm/domain/install_service.py
+++ b/cpm/domain/install_service.py
@@ -9,7 +9,7 @@ class InstallService(object):
 
     def install(self, name, version):
         project = self.project_loader.load()
-        if Bit(name, version) in project.bits:
+        if Bit(name, version) in project.build.bits:
             print(f'bit already installed: {name}:{version}')
             return
         self._log_install_or_upgrade(project, name, version)
@@ -19,7 +19,7 @@ class InstallService(object):
             self.install(bit_name, version)
 
     def _log_install_or_upgrade(self, project, name, version):
-        installed_bit = next((bit for bit in project.bits if bit.name == name), None)
+        installed_bit = next((bit for bit in project.build.bits if bit.name == name), None)
         if installed_bit:
             print(f'{"upgrading" if installed_bit.version < version else "downgrading"} {name}:{installed_bit.version} -> {version}')
         else:
@@ -27,9 +27,9 @@ class InstallService(object):
 
     def install_project_bits(self):
         project = self.project_loader.load()
-        for bit_name, version in project.declared_bits.items():
+        for bit_name, version in project.build.declared_bits.items():
             self.install(bit_name, version)
-        for bit_name, version in project.declared_test_bits.items():
+        for bit_name, version in project.test.declared_bits.items():
             self.install(bit_name, version)
 
 

--- a/cpm/domain/project.py
+++ b/cpm/domain/project.py
@@ -27,57 +27,57 @@ class ProjectAction(object):
     command: str
 
 
-class Project(object):
-    def __init__(self, name):
-        self.name = name
-        self.version = "0.1"
-        self.tests = []
+class CompileRecipe(object):
+    def __init__(self):
         self.declared_bits = {}
-        self.declared_test_bits = {}
         self.bits = []
         self.sources = []
         self.packages = []
         self.compile_flags = []
         self.include_directories = []
         self.link_options = LinkOptions()
-        self.actions = []
-        self.targets = {}
-        self.test_packages = []
-        self.test_include_directories = []
-        self.test_sources = []
-
-    def add_target(self, target):
-        self.targets[target.name] = target
 
     def add_bit(self, bit):
         self.bits.append(bit)
 
-    def add_sources(self, sources):
-        self.sources.extend(sources)
-
-    def add_tests(self, tests):
-        self.tests.extend(tests)
-
     def add_package(self, package):
         self.packages.append(package)
+
+    def add_sources(self, sources):
+        self.sources.extend(sources)
 
     def add_include_directory(self, directory):
         self.include_directories.append(directory)
 
-    def add_test_package(self, package):
-        self.test_packages.append(package)
-
-    def add_test_include_directory(self, directory):
-        self.test_include_directories.append(directory)
-
-    def add_test_sources(self, sources):
-        self.test_sources.extend(sources)
-
     def add_library(self, library):
         self.link_options.libraries.append(library)
+
+    def add_compile_flags(self, compile_flags):
+        self.compile_flags.extend(compile_flags)
+
+
+class Project(object):
+    def __init__(self, name):
+        self.name = name
+        self.version = "0.1"
+        self.tests = []
+        self.test = CompileRecipe()
+        self.build = CompileRecipe()
+        self.actions = []
+        self.targets = {}
+
+    def add_target(self, target):
+        self.targets[target.name] = target
+
+    def add_build_recipe(self, recipe):
+        self.build = recipe
+
+    def add_test_recipe(self, recipe):
+        self.test = recipe
+
+    def add_tests(self, tests):
+        self.tests.extend(tests)
 
     def add_action(self, project_action):
         self.actions.append(project_action)
 
-    def add_compile_flags(self, compile_flags):
-        self.compile_flags.extend(compile_flags)

--- a/test/domain/test_bit_packager.py
+++ b/test/domain/test_bit_packager.py
@@ -19,7 +19,7 @@ class TestBitPackager(unittest.TestCase):
         filesystem.directory_exists.return_value = True
         packager = BitPackager(filesystem)
         project = Project('cest')
-        project.add_package(Package('fakeit'))
+        project.build.add_package(Package('fakeit'))
 
         self.assertRaises(PackagingFailure, packager.pack, project, 'dist')
 
@@ -28,8 +28,8 @@ class TestBitPackager(unittest.TestCase):
         filesystem.directory_exists.return_value = False
         packager = BitPackager(filesystem)
         project = Project('cest')
-        project.add_package(Package('api'))
-        project.add_package(Package('domain'))
+        project.build.add_package(Package('api'))
+        project.build.add_package(Package('domain'))
 
         packager.pack(project, 'dist')
 

--- a/test/domain/test_cmake_recipe.py
+++ b/test/domain/test_cmake_recipe.py
@@ -35,8 +35,8 @@ class TestCMakeRecipe(unittest.TestCase):
     def test_recipe_generation_with_target_link_libraries(self):
         filesystem = self.filesystemMockWithoutRecipeFiles()
         project = _project_without_sources('DeathStarBackend')
-        project.add_library('pthread')
-        project.add_library('rt')
+        project.build.add_library('pthread')
+        project.build.add_library('rt')
         cmake_recipe = CMakeRecipe(filesystem)
 
         cmake_recipe.generate(project)
@@ -55,8 +55,8 @@ class TestCMakeRecipe(unittest.TestCase):
     def test_recipe_generation_with_one_package(self):
         filesystem = self.filesystemMockWithoutRecipeFiles()
         project = _project_without_sources('DeathStarBackend')
-        project.add_package(Package('package'))
-        project.add_include_directory('package')
+        project.build.add_package(Package('package'))
+        project.build.add_include_directory('package')
         cmake_recipe = CMakeRecipe(filesystem)
 
         cmake_recipe.generate(project)
@@ -74,10 +74,10 @@ class TestCMakeRecipe(unittest.TestCase):
     def test_recipe_generation_with_one_package_with_global_compile_flags(self):
         filesystem = self.filesystemMockWithoutRecipeFiles()
         project = _project_without_sources('DeathStarBackend')
-        project.add_package(Package('package', sources=['package.cpp']))
-        project.add_include_directory('package')
-        project.add_sources(['package.cpp'])
-        project.compile_flags = ['-g']
+        project.build.add_package(Package('package', sources=['package.cpp']))
+        project.build.add_include_directory('package')
+        project.build.add_sources(['package.cpp'])
+        project.build.compile_flags = ['-g']
         cmake_recipe = CMakeRecipe(filesystem)
 
         cmake_recipe.generate(project)
@@ -95,9 +95,9 @@ class TestCMakeRecipe(unittest.TestCase):
     def test_recipe_generation_with_one_package_with_cflags(self):
         filesystem = self.filesystemMockWithoutRecipeFiles()
         project = _project_without_sources('DeathStarBackend')
-        project.add_package(Package('package', cflags=['-std=c++11', '-DMACRO'], sources=['package.cpp']))
-        project.add_include_directory('package')
-        project.add_sources(['package.cpp'])
+        project.build.add_package(Package('package', cflags=['-std=c++11', '-DMACRO'], sources=['package.cpp']))
+        project.build.add_include_directory('package')
+        project.build.add_sources(['package.cpp'])
         cmake_recipe = CMakeRecipe(filesystem)
 
         cmake_recipe.generate(project)
@@ -115,11 +115,11 @@ class TestCMakeRecipe(unittest.TestCase):
     def test_recipe_generation_with_many_packages_with_cflags(self):
         filesystem = self.filesystemMockWithoutRecipeFiles()
         project = _project_without_sources('DeathStarBackend')
-        project.add_package(Package('package1', cflags=['-std=c++11'], sources=['package1.cpp']))
-        project.add_package(Package('package2', cflags=['-Wall'], sources=['package2.cpp']))
-        project.add_include_directory('package')
-        project.add_sources(['package1.cpp'])
-        project.add_sources(['package2.cpp'])
+        project.build.add_package(Package('package1', cflags=['-std=c++11'], sources=['package1.cpp']))
+        project.build.add_package(Package('package2', cflags=['-Wall'], sources=['package2.cpp']))
+        project.build.add_include_directory('package')
+        project.build.add_sources(['package1.cpp'])
+        project.build.add_sources(['package2.cpp'])
         cmake_recipe = CMakeRecipe(filesystem)
 
         cmake_recipe.generate(project)
@@ -194,7 +194,7 @@ class TestCMakeRecipe(unittest.TestCase):
     def test_recipe_generation_with_one_bit_and_link_libraries(self):
         filesystem = self.filesystemMockWithoutRecipeFiles()
         project = _project_with_one_bit('DeathStarBackend', sources=['bit.cpp'], cflags=['-DDEFINE'])
-        project.add_library('boost')
+        project.build.add_library('boost')
         cmake_recipe = CMakeRecipe(filesystem)
 
         cmake_recipe.generate(project)
@@ -268,7 +268,7 @@ class TestCMakeRecipe(unittest.TestCase):
         filesystem = self.filesystemMockWithoutRecipeFiles()
         project = _project_with_one_bit('DeathStarBackend', ['bit.cpp'])
         project.tests = ['tests/test_suite.cpp']
-        project.add_library('boost')
+        project.build.add_library('boost')
         cmake_recipe = CMakeRecipe(filesystem)
 
         cmake_recipe.generate(project)
@@ -323,8 +323,8 @@ class TestCMakeRecipe(unittest.TestCase):
         filesystem = self.filesystemMockWithoutRecipeFiles()
         project = _project_with_sources('DeathStarBackend', ['source.cpp'])
         project.tests = ['tests/test_suite.cpp']
-        project.add_library('pthread')
-        project.add_library('rt')
+        project.build.add_library('pthread')
+        project.build.add_library('rt')
         cmake_recipe = CMakeRecipe(filesystem)
 
         cmake_recipe.generate(project)
@@ -375,7 +375,7 @@ class TestCMakeRecipe(unittest.TestCase):
     def test_recipe_generation_with_one_test_suite_and_test_include_directories(self):
         filesystem = self.filesystemMockWithoutRecipeFiles()
         project = _project_with_sources('DeathStarBackend', ['source.cpp'])
-        project.test_include_directories = ['mocks', 'fakes']
+        project.test.include_directories = ['mocks', 'fakes']
         project.tests = ['tests/test_suite.cpp']
         cmake_recipe = CMakeRecipe(filesystem)
 
@@ -402,7 +402,7 @@ class TestCMakeRecipe(unittest.TestCase):
     def test_recipe_generation_with_one_test_suite_and_test_sources(self):
         filesystem = self.filesystemMockWithoutRecipeFiles()
         project = _project_with_sources('DeathStarBackend', ['source.cpp'])
-        project.test_sources = ['mocks/mock.cpp', 'mocks/fake.cpp']
+        project.test.sources = ['mocks/mock.cpp', 'mocks/fake.cpp']
         project.tests = ['tests/test_suite.cpp']
         cmake_recipe = CMakeRecipe(filesystem)
 
@@ -615,21 +615,21 @@ class TestCMakeRecipe(unittest.TestCase):
 
 def _project_without_sources(name):
     project = Project(name)
-    project.sources = ['main.cpp']
+    project.build.sources = ['main.cpp']
     return project
 
 
 def _project_with_one_bit(name, sources=[], cflags=[]):
     project = Project(name)
-    project.sources = ['main.cpp']
+    project.build.sources = ['main.cpp']
     bit = Bit('cest')
     bit.add_package(Package('bits/cest', sources=sources, cflags=cflags))
     bit.add_sources(sources)
-    project.add_bit(bit)
+    project.build.add_bit(bit)
     return project
 
 
 def _project_with_sources(name, sources):
     project = Project(name)
-    project.sources = ['main.cpp'] + sources
+    project.build.sources = ['main.cpp'] + sources
     return project

--- a/test/domain/test_creation_service.py
+++ b/test/domain/test_creation_service.py
@@ -70,6 +70,7 @@ class TestCreationService(unittest.TestCase):
             './project.yaml',
             'name: AwesomeProject\n'
         )
+
     def test_creation_service_generates_default_sample_code_when_selected(self):
         filesystem = mock.MagicMock()
         project_loader = mock.MagicMock()
@@ -97,5 +98,5 @@ class TestCreationService(unittest.TestCase):
         project = creation_service.create(creation_options)
 
         assert project.name == 'AwesomeProject'
-        assert project.sources == ['main.cpp']
+        assert project.build.sources == ['main.cpp']
 

--- a/test/domain/test_install_service.py
+++ b/test/domain/test_install_service.py
@@ -89,7 +89,7 @@ class TestInstallService(unittest.TestCase):
         bit_installer = MagicMock()
         bit_download = MagicMock()
         project = Project('Project')
-        project.declared_bits = {
+        project.build.declared_bits = {
             'cest': '1.0',
             'fakeit': '1.0',
         }
@@ -110,7 +110,7 @@ class TestInstallService(unittest.TestCase):
         bit_installer = MagicMock()
         bit_download = MagicMock()
         project = Project('Project')
-        project.declared_test_bits = {
+        project.test.declared_bits = {
             'cest': '1.0',
             'fakeit': '1.0',
         }
@@ -130,7 +130,7 @@ class TestInstallService(unittest.TestCase):
         cpm_hub_connector = MagicMock()
         bit_installer = MagicMock()
         project = Project('Project')
-        project.add_bit(Bit('cest', '1.0'))
+        project.build.add_bit(Bit('cest', '1.0'))
         project_loader.load.return_value = project
         service = InstallService(project_loader, bit_installer, cpm_hub_connector)
 
@@ -143,7 +143,7 @@ class TestInstallService(unittest.TestCase):
         cpm_hub_connector = MagicMock()
         bit_installer = MagicMock()
         project = Project('Project')
-        project.add_bit(Bit('cest', '1.0'))
+        project.build.add_bit(Bit('cest', '1.0'))
         project_loader.load.return_value = project
         service = InstallService(project_loader, bit_installer, cpm_hub_connector)
 

--- a/test/domain/test_project_loader.py
+++ b/test/domain/test_project_loader.py
@@ -78,7 +78,7 @@ class TestProjectLoader(unittest.TestCase):
         loaded_project = loader.load()
 
         assert loaded_project.name == 'Project'
-        assert loaded_project.declared_bits == {
+        assert loaded_project.build.declared_bits == {
             'cest': '1.0'
         }
 
@@ -87,8 +87,8 @@ class TestProjectLoader(unittest.TestCase):
         filesystem = mock.MagicMock()
         yaml_handler.load.return_value = {
             'name': 'Project',
-            'test_bits': {
-                'cest': '1.0'
+            'test': {
+                'bits': {'cest': '1.0'}
             }
         }
         loader = ProjectLoader(yaml_handler, filesystem)
@@ -96,7 +96,7 @@ class TestProjectLoader(unittest.TestCase):
         loaded_project = loader.load()
 
         assert loaded_project.name == 'Project'
-        assert loaded_project.declared_test_bits == {
+        assert loaded_project.test.declared_bits == {
             'cest': '1.0'
         }
 
@@ -114,8 +114,8 @@ class TestProjectLoader(unittest.TestCase):
         project = loader.load()
 
         assert project.name == 'Project'
-        assert Package(path='cpm-hub') in project.packages
-        assert project.include_directories == ['.']
+        assert Package(path='cpm-hub') in project.build.packages
+        assert project.build.include_directories == ['.']
 
     def test_loading_project_with_one_package_with_cflags(self):
         yaml_handler = mock.MagicMock()
@@ -133,7 +133,7 @@ class TestProjectLoader(unittest.TestCase):
 
         project = loader.load()
 
-        assert Package(path='cpm-hub', cflags=['-std=c++11']) in project.packages
+        assert Package(path='cpm-hub', cflags=['-std=c++11']) in project.build.packages
 
     def test_loading_project_with_with_libraries_link_option(self):
         yaml_handler = mock.MagicMock()
@@ -149,7 +149,7 @@ class TestProjectLoader(unittest.TestCase):
 
         project = loader.load()
 
-        assert 'pthread' in project.link_options.libraries
+        assert 'pthread' in project.build.link_options.libraries
 
     def test_loading_project_with_with_global_compile_flags(self):
         yaml_handler = mock.MagicMock()
@@ -163,7 +163,7 @@ class TestProjectLoader(unittest.TestCase):
 
         project = loader.load()
 
-        assert '-g' in project.compile_flags
+        assert '-g' in project.build.compile_flags
 
     def test_loading_project_with_one_target(self):
         yaml_handler = mock.MagicMock()
@@ -198,8 +198,8 @@ class TestProjectLoader(unittest.TestCase):
         loaded_project = loader.load()
 
         assert loaded_project.name == 'Project'
-        assert loaded_project.bits == [Bit('cest')]
-        assert loaded_project.include_directories == ['bits/cest']
+        assert loaded_project.build.bits == [Bit('cest')]
+        assert loaded_project.build.include_directories == ['bits/cest']
 
     def test_loading_package_with_sources(self):
         filesystem = mock.MagicMock()
@@ -297,12 +297,12 @@ class TestProjectLoader(unittest.TestCase):
         filesystem.parent_directory.return_value = '.'
         yaml_handler.load.return_value = {
             'name': 'Project',
-            'test_packages': {'mocks': None},
+            'test': { 'packages': {'mocks': None} }
         }
         loader = ProjectLoader(yaml_handler, filesystem)
 
         project = loader.load()
 
         assert project.name == 'Project'
-        assert Package(path='mocks') in project.test_packages
-        assert project.test_include_directories == ['.']
+        assert Package(path='mocks') in project.test.packages
+        assert project.test.include_directories == ['.']


### PR DESCRIPTION
With this PR, the users have available a new `test` field in the project descriptor where the test compilation can be configured. For example, user-defined mocks should be compiled only for test targets. This PR supersedes the previous change at #156.

```yaml
project: 'Project'
test: # the declarations will be used for testing only
    bits: []
    packages: []
    compile_flags: []
    link_options: 
        libraries: []
```