### PR TITLE
Include libraries for testing only in cmake recipe

### DIFF
--- a/cpm/domain/cmake_recipe.py
+++ b/cpm/domain/cmake_recipe.py
@@ -55,7 +55,7 @@ class CMakeRecipe(object):
                 builder.add_executable(executable, [test_file] + project.test.sources, object_libraries) \
                     .set_target_properties(executable, 'COMPILE_FLAGS', ['-std=c++11', '-g'])
                 bits_with_sources = list(filter(lambda p: p.sources, project.build.bits))
-                link_libraries = [bit.name for bit in bits_with_sources] + project.build.link_options.libraries
+                link_libraries = [bit.name for bit in bits_with_sources] + project.build.link_options.libraries + project.test.link_options.libraries
                 if link_libraries:
                     builder.target_link_libraries(executable, link_libraries)
                 if project.test.include_directories:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cpm-cli
-version = 0.8
+version = 0.9
 description = Chromos Package Manager
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/test/domain/test_cmake_recipe.py
+++ b/test/domain/test_cmake_recipe.py
@@ -292,6 +292,35 @@ class TestCMakeRecipe(unittest.TestCase):
             ')\n'
         )
 
+    def test_recipe_generation_with_one_test_suite_and_one_bit_and_test_link_libraries(self):
+        filesystem = self.filesystemMockWithoutRecipeFiles()
+        project = _project_with_one_bit('DeathStarBackend', ['bit.cpp'])
+        project.tests = ['tests/test_suite.cpp']
+        project.build.add_library('boost')
+        project.test.add_library('cpputest')
+        cmake_recipe = CMakeRecipe(filesystem)
+
+        cmake_recipe.generate(project)
+
+        filesystem.create_directory.assert_called_once_with('build')
+        filesystem.create_file.assert_called_once_with(
+            'CMakeLists.txt',
+
+            'cmake_minimum_required (VERSION 3.7)\n'
+            'project(DeathStarBackend)\n'
+            'include_directories()\n'
+            'add_library(cest STATIC bit.cpp)\n'
+            'add_executable(DeathStarBackend main.cpp)\n'
+            'target_link_libraries(DeathStarBackend cest boost)\n'
+            'add_executable(test_suite tests/test_suite.cpp)\n'
+            'set_target_properties(test_suite PROPERTIES COMPILE_FLAGS "-std=c++11 -g")\n'
+            'target_link_libraries(test_suite cest boost cpputest)\n'
+            'add_custom_target(tests\n'
+            '    COMMAND echo "> Done"\n'
+            '    DEPENDS test_suite\n'
+            ')\n'
+        )
+
     def test_recipe_generation_with_many_test_suites(self):
         filesystem = self.filesystemMockWithoutRecipeFiles()
         project = _project_with_sources('DeathStarBackend', ['source.cpp'])


### PR DESCRIPTION
This PR makes effective the project descriptor option for defining libraries to be linked only in the tests.