### PR TITLE
Improve compilation and error processing when building inside containers

### DIFF
--- a/cpm/api/test.py
+++ b/cpm/api/test.py
@@ -22,7 +22,7 @@ def run_tests(test_service, files_or_dirs=None, target='default'):
     except NotACpmProject:
         return Result(FAIL, 'error: not a cpm project')
     except BuildError as e:
-        return Result(FAIL, f'error: build failed')
+        return Result(FAIL, f'error: failed building tests')
     except TestsFailed:
         return Result(FAIL, '✖ FAIL')
     except NoTestsFound:

--- a/cpm/domain/project_commands.py
+++ b/cpm/domain/project_commands.py
@@ -12,14 +12,7 @@ class ProjectCommands(object):
     def build(self, project, target_name):
         if not filesystem.directory_exists(constants.BUILD_DIRECTORY):
             filesystem.create_directory(constants.BUILD_DIRECTORY)
-        if project.targets[target_name].image or project.targets[target_name].dockerfile:
-            self.__build_inside_container(project, target_name)
-        else:
-            self.__build_in_host(project)
-
-    def __build_in_host(self, project):
-        self.__run_command(constants.CMAKE_COMMAND, '-G', 'Ninja', '..')
-        self.__run_command(constants.NINJA_COMMAND, project.name)
+        self.__build(project, target_name, project.name)
 
     def clean(self, project):
         if filesystem.directory_exists(constants.BUILD_DIRECTORY):
@@ -30,8 +23,22 @@ class ProjectCommands(object):
     def build_tests(self, project, target_name, files_or_dirs):
         if not filesystem.directory_exists(constants.BUILD_DIRECTORY):
             filesystem.create_directory(constants.BUILD_DIRECTORY)
-        self.__run_command(constants.CMAKE_COMMAND, '-G', 'Ninja', '..')
-        self.__run_command('ninja', 'tests')
+        self.__build(project, target_name, 'tests')
+
+    def __build(self, project, target_name, goal):
+        if project.targets[target_name].image:
+            self.__build_using_image(project, project.targets[target_name].image, goal)
+        elif project.targets[target_name].dockerfile:
+            self.__build_using_dockerfile(project, project.targets[target_name].dockerfile, goal)
+        else:
+            self.__build_goal(goal)
+
+    def __build_goal(self, goal):
+        if any(result.returncode != 0 for result in [
+            self.__run_command(constants.CMAKE_COMMAND, '-G', 'Ninja', '..'),
+            self.__run_command(constants.NINJA_COMMAND, goal)
+        ]):
+            raise BuildError
 
     def run_tests(self, project, target_name, files_or_dirs):
         test_results = [self.run_test(test.name) for test in project.tests]
@@ -50,23 +57,28 @@ class ProjectCommands(object):
     def __run_command(self, *args, cwd=constants.BUILD_DIRECTORY):
         return subprocess.run([*args], cwd=cwd)
 
-    def __build_inside_container(self, project, target_name):
+    def __build_using_image(self, project, image_name, goal):
         client = docker.from_env()
-        if project.targets[target_name].image:
-            image_name = project.targets[target_name].image
-            try:
-                client.images.pull(image_name)
-            except docker.errors.ImageNotFound:
-                raise DockerImageNotFound(image_name)
-            except docker.errors.NotFound:
-                raise DockerImageNotFound(image_name)
-        else:
-            image_name = f'{project.name}_cpm_build'
-            client.images.build(path=project.targets[target_name].dockerfile, tag=image_name)
+        print(f'pulling {image_name}')
+        try:
+            client.images.pull(image_name)
+        except docker.errors.ImageNotFound:
+            raise DockerImageNotFound(image_name)
+        except docker.errors.NotFound:
+            raise DockerImageNotFound(image_name)
+        self.__build_inside_container(client, goal, image_name, project)
 
+    def __build_using_dockerfile(self, project, dockerfile, goal):
+        client = docker.from_env()
+        print(f'building image from {dockerfile}')
+        image_name = f'{project.name}_cpm_build'
+        client.images.build(path=dockerfile, tag=image_name)
+        self.__build_inside_container(client, goal, image_name, project)
+
+    def __build_inside_container(self, client, goal, image_name, project):
         filesystem.create_file(
             f'{constants.BUILD_DIRECTORY}/build.sh',
-            f'{constants.CMAKE_COMMAND} -G Ninja /{project.name} && {constants.NINJA_COMMAND} {project.name}'
+            f'{constants.CMAKE_COMMAND} -G Ninja /{project.name} && {constants.NINJA_COMMAND} {goal}'
         )
         container = client.containers.run(
             image_name,
@@ -74,11 +86,15 @@ class ProjectCommands(object):
             working_dir=f'/{project.name}/build',
             volumes={f'{os.getcwd()}': {'bind': f'/{project.name}', 'mode': 'rw'}},
             user=f'{os.getuid()}:{os.getgid()}',
-            auto_remove=True,
             detach=True
         )
+        print(f'building inside {container.short_id}')
         for log in container.logs(stream=True):
             sys.stdout.write(log.decode())
+        exit_code = container.wait()
+        if exit_code['StatusCode'] != 0:
+            raise BuildError
+        container.remove()
 
 
 def _ignore_exception(call):


### PR DESCRIPTION
This pull request improves the build process when building the project inside a container. The build is performed inside the container for both the tests and the project binary itself. Tests will not be run inside the container, but in the host (future feature?). 

The container will be automatically removed once the build process finishes. Return codes are forwarded to the host.