### PR TITLE
Allow defining a list of post_build actions to be run inside container

### DIFF
--- a/cpm/domain/project/project.py
+++ b/cpm/domain/project/project.py
@@ -19,6 +19,7 @@ class Target:
     main: str = 'main.cpp'
     image: str = ''
     dockerfile: str = ''
+    post_build: list = field(default_factory=list)
     packages: list = field(default_factory=list)
     include_directories: set = field(default_factory=set)
     cflags: list = field(default_factory=list)

--- a/cpm/domain/project/project_composer.py
+++ b/cpm/domain/project/project_composer.py
@@ -23,6 +23,7 @@ def compose_target(target_name, project_descriptor):
     target.libraries = project_descriptor.build.libraries + target_description.build.libraries
     target.image = target_description.image
     target.dockerfile = target_description.dockerfile
+    target.post_build = target_description.post_build
     compose_packages(project_descriptor.build.packages, target)
     compose_packages(target_description.build.packages, target)
     for bit_description in project_descriptor.build.bits.values():

--- a/cpm/domain/project/project_descriptor.py
+++ b/cpm/domain/project/project_descriptor.py
@@ -41,6 +41,7 @@ class TargetDescription:
     main: str = 'main.cpp'
     build: CompilationPlan = field(default_factory=CompilationPlan)
     test: CompilationPlan = field(default_factory=CompilationPlan)
+    post_build: list = field(default_factory=list)
 
 
 @dataclass

--- a/cpm/domain/project/project_descriptor_parser.py
+++ b/cpm/domain/project/project_descriptor_parser.py
@@ -28,7 +28,7 @@ def parse_targets(targets_description):
         'default': TargetDescription('default')
     }
     for target_name in targets_description:
-        targets[target_name] = parse_target(target_name, targets_description[target_name])
+        targets[target_name] = parse_target(target_name, targets_description.get(target_name, {}))
     return targets
 
 
@@ -38,6 +38,7 @@ def parse_target(target_name, target_description):
     target.dockerfile = target_description.get('dockerfile', '')
     target.format = target_description.get('format', 'binary')
     target.main = target_description.get('main', '')
+    target.post_build = target_description.get('post_build', [])
     target.build = parse_compilation_plan(target_description.get('build', {}))
     target.test = parse_compilation_plan(target_description.get('test', {}))
     return target

--- a/cpm/domain/project_commands.py
+++ b/cpm/domain/project_commands.py
@@ -105,8 +105,7 @@ class ProjectCommands(object):
         container.remove()
 
     def __post_build(self, project):
-        nl = "\n"
-        return f'( cd .. && {nl.join(project.target.post_build)} )' if project.target.post_build else ''
+        return '\n'.join([f'( cd .. && {post_build} )' for post_build in project.target.post_build])
 
     def tests_from_args(self, project, target_name, files_or_dirs):
         if not files_or_dirs:

--- a/test/domain/test_project_composer.py
+++ b/test/domain/test_project_composer.py
@@ -64,6 +64,7 @@ class TestProjectComposer(unittest.TestCase):
                         'ldflags': ['-pg'],
                         'libraries': ['pthread']
                     },
+                    'post_build': ['./post_build.sh']
                 }
             }
         }
@@ -79,6 +80,7 @@ class TestProjectComposer(unittest.TestCase):
         assert project.target.ldflags == ['-pg']
         assert project.target.libraries == ['pthread']
         assert project.target.include_directories == {'.'}
+        assert project.target.post_build == ['./post_build.sh']
 
     @mock.patch('cpm.domain.project.project_composer.filesystem')
     def test_should_compose_project_from_project_description_with_one_target_test_package(self, filesystem):

--- a/test/domain/test_project_descriptor_parser.py
+++ b/test/domain/test_project_descriptor_parser.py
@@ -103,7 +103,10 @@ class TestProjectDescriptorParser(unittest.TestCase):
                         'packages': {
                             'arduino': {},
                         }
-                    }
+                    },
+                    'post_build': [
+                        './scripts/package.sh'
+                    ]
                 }
             }
         }
@@ -112,6 +115,7 @@ class TestProjectDescriptorParser(unittest.TestCase):
             project_descriptor.PackageDescription('arduino')
         ]
         assert project.targets['arduino'].dockerfile == 'Dockerfile'
+        assert project.targets['arduino'].post_build == ['./scripts/package.sh']
 
     def test_parse_project_descriptor_with_target_test_compilation_plan(self):
         yaml_contents = {

--- a/test/e2e/test_cpm.py
+++ b/test/e2e/test_cpm.py
@@ -59,7 +59,7 @@ class TestCpm(unittest.TestCase):
     def test_build_from_docker_image_with_post_build(self):
         os.chdir(self.PROJECT_DIRECTORY)
         self.set_target_image('default', 'cpmbits/ubuntu:20.04')
-        self.set_post_build('default', [f'rm build/{self.PROJECT_NAME}'])
+        self.set_post_build('default', [f'ls', f'rm build/{self.PROJECT_NAME}'])
         install.execute(['-s', 'http://localhost:8000'])
         result = build.execute([])
         assert result == Result(0, 'Build finished')

--- a/test/e2e/test_cpm.py
+++ b/test/e2e/test_cpm.py
@@ -56,6 +56,15 @@ class TestCpm(unittest.TestCase):
         result = build.execute([])
         assert result == Result(0, 'Build finished')
 
+    def test_build_from_docker_image_with_post_build(self):
+        os.chdir(self.PROJECT_DIRECTORY)
+        self.set_target_image('default', 'cpmbits/ubuntu:20.04')
+        self.set_post_build('default', [f'rm build/{self.PROJECT_NAME}'])
+        install.execute(['-s', 'http://localhost:8000'])
+        result = build.execute([])
+        assert result == Result(0, 'Build finished')
+        assert not filesystem.file_exists(f'build/{self.PROJECT_NAME}')
+
     def test_build_from_dockerfile(self):
         os.chdir(self.PROJECT_DIRECTORY)
         self.set_target_dockerfile('default', f'../environment')
@@ -137,6 +146,13 @@ class TestCpm(unittest.TestCase):
         with open(f'project.yaml') as stream:
             project_descriptor = yaml.safe_load(stream)
         project_descriptor.setdefault('targets', {}).setdefault(target_name, {})['image'] = image
+        with open(f'project.yaml', 'w') as stream:
+            yaml.dump(project_descriptor, stream)
+
+    def set_post_build(self, target_name, post_build):
+        with open(f'project.yaml') as stream:
+            project_descriptor = yaml.safe_load(stream)
+        project_descriptor.setdefault('targets', {}).setdefault(target_name, {})['post_build'] = post_build
         with open(f'project.yaml', 'w') as stream:
             yaml.dump(project_descriptor, stream)
 


### PR DESCRIPTION
This PR allows the user defining a target `post_build` action. The post-build will be run inside the container and currently it won't be used at all if the project is not compiled inside an image:

```yaml
targets:
  default:
    image: 'ubuntu:20.04'
    post_build: './scripts/create_installer.sh'
```

Closes #194 