### PR TITLE
Allow tests to be run inside container

### DIFF
--- a/cpm/domain/project/project.py
+++ b/cpm/domain/project/project.py
@@ -20,6 +20,7 @@ class Target:
     main: str = 'main.cpp'
     image: str = ''
     dockerfile: str = ''
+    test_image: str = ''
     post_build: list = field(default_factory=list)
     packages: list = field(default_factory=list)
     include_directories: set = field(default_factory=set)
@@ -40,6 +41,7 @@ class TestSuite:
     cppflags: list = field(default_factory=list)
     ldflags: list = field(default_factory=list)
     libraries: list = field(default_factory=list)
+
 
 @dataclass
 class Test:

--- a/cpm/domain/project/project_composer.py
+++ b/cpm/domain/project/project_composer.py
@@ -24,6 +24,7 @@ def compose_target(target_name, project_descriptor):
     target.include_directories.update(project_descriptor.build.includes)
     target.main = target_description.main
     target.image = target_description.image
+    target.test_image = target_description.test_image
     target.dockerfile = target_description.dockerfile
     target.post_build = target_description.post_build
     compose_packages(project_descriptor.build.packages, target)

--- a/cpm/domain/project/project_descriptor.py
+++ b/cpm/domain/project/project_descriptor.py
@@ -36,13 +36,14 @@ class ProjectInformation:
 @dataclass
 class TargetDescription:
     name: str
-    image: str = ''
-    dockerfile: str = ''
-    format: str = 'binary'
     main: str = 'main.cpp'
+    format: str = 'binary'
     build: CompilationPlan = field(default_factory=CompilationPlan)
     test: CompilationPlan = field(default_factory=CompilationPlan)
     post_build: list = field(default_factory=list)
+    dockerfile: str = ''
+    image: str = ''
+    test_image: str = ''
 
 
 @dataclass

--- a/cpm/domain/project/project_descriptor_parser.py
+++ b/cpm/domain/project/project_descriptor_parser.py
@@ -35,6 +35,7 @@ def parse_targets(targets_description):
 def parse_target(target_name, target_description):
     target = TargetDescription(target_name)
     target.image = target_description.get('image', '')
+    target.test_image = target_description.get('test_image', '')
     target.dockerfile = target_description.get('dockerfile', '')
     target.format = target_description.get('format', 'binary')
     target.main = target_description.get('main', '')

--- a/cpm/domain/project_commands.py
+++ b/cpm/domain/project_commands.py
@@ -21,29 +21,20 @@ class ProjectCommands(object):
             filesystem.remove_directory(constants.BUILD_DIRECTORY)
         _ignore_exception(lambda: filesystem.delete_file(constants.CMAKELISTS))
 
-    def build_tests(self, project, target_name, files_or_dirs):
+    def build_tests(self, project, files_or_dirs):
         if not filesystem.directory_exists(constants.BUILD_DIRECTORY):
             filesystem.create_directory(constants.BUILD_DIRECTORY)
         if not files_or_dirs:
-            self.__build(project, ['tests'])
+            self.__build_tests(project, ['tests'])
         else:
-            tests_to_run = self.tests_from_args(project, target_name, files_or_dirs)
-            self.__build(project, [test.name for test in tests_to_run])
+            tests_to_run = self.tests_from_args(project, files_or_dirs)
+            self.__build_tests(project, [test.name for test in tests_to_run])
 
-    def run_tests(self, project, target_name, files_or_dirs):
-        tests_to_run = project.test.test_suites if not files_or_dirs else self.tests_from_args(project, target_name, files_or_dirs)
-        test_results = [self.run_test(test.name) for test in tests_to_run]
-        if any(result.returncode != 0 for result in test_results):
-            raise TestsFailed('tests failed')
-
-    def run_test(self, executable):
-        result = subprocess.run(
-            [f'./{executable}'],
-            cwd=constants.BUILD_DIRECTORY
-        )
-        if result.returncode < 0:
-            print(f'{executable} failed with {result.returncode} ({signal.Signals(-result.returncode).name})')
-        return result
+    def __build_tests(self, project, goals, post_build=''):
+        if project.target.test_image:
+            self.__build_using_image(project, project.target.test_image, goals, post_build)
+        else:
+            self.__build_goal(goals)
 
     def __build(self, project, goals, post_build=''):
         if project.target.image:
@@ -60,9 +51,6 @@ class ProjectCommands(object):
         ]):
             raise BuildError
 
-    def __run_command(self, *args, cwd=constants.BUILD_DIRECTORY):
-        return subprocess.run([*args], cwd=cwd)
-
     def __build_using_image(self, project, image_name, goals, post_build):
         client = docker.from_env()
         print(f'pulling {image_name}')
@@ -72,16 +60,16 @@ class ProjectCommands(object):
             raise DockerImageNotFound(image_name)
         except docker.errors.NotFound:
             raise DockerImageNotFound(image_name)
-        self.__build_inside_container(client, goals, image_name, project, post_build)
+        self.__build_inside_container(client, project, image_name, goals, post_build)
 
-    def __build_using_dockerfile(self, project, dockerfile, goal, post_build):
+    def __build_using_dockerfile(self, project, dockerfile, goals, post_build):
         client = docker.from_env()
         print(f'building image from {dockerfile}')
         image_name = f'{project.name}_cpm_build'
         client.images.build(path=dockerfile, tag=image_name)
-        self.__build_inside_container(client, goal, image_name, project, post_build)
+        self.__build_inside_container(client, project, image_name, goals, post_build)
 
-    def __build_inside_container(self, client, goals, image_name, project, post_build):
+    def __build_inside_container(self, client, project, image_name, goals, post_build):
         filesystem.create_file(
             f'{constants.BUILD_DIRECTORY}/build.sh',
             f'{constants.CMAKE_COMMAND} -G Ninja /{project.name} && {constants.NINJA_COMMAND} {" ".join(goals)}\n'
@@ -103,24 +91,71 @@ class ProjectCommands(object):
             raise BuildError
         container.remove()
 
+    def run_tests(self, project, files_or_dirs):
+        tests_to_run = project.test.test_suites if not files_or_dirs else self.tests_from_args(project, files_or_dirs)
+        if project.target.test_image:
+            test_results = self.__run_tests_inside_container(project, tests_to_run)
+        else:
+            test_results = [self.run_test(test.name) for test in tests_to_run]
+        if any(result != 0 for result in test_results):
+            raise TestsFailed('tests failed')
+
+    def run_test(self, executable):
+        result = subprocess.run(
+            [f'./{constants.BUILD_DIRECTORY}/{executable}']
+        )
+        if result.returncode < 0:
+            print(f'{executable} failed with {result.returncode} ({signal.Signals(-result.returncode).name})')
+        return result.returncode
+
+    def __run_tests_inside_container(self, project, tests_to_run):
+        client = docker.from_env()
+        image_name = project.target.test_image
+        try:
+            client.images.pull(image_name)
+        except docker.errors.ImageNotFound:
+            raise DockerImageNotFound(image_name)
+        except docker.errors.NotFound:
+            raise DockerImageNotFound(image_name)
+        return [self.__run_test_inside_container(project, client, image_name, test.name) for test in tests_to_run]
+
+    def __run_test_inside_container(self, project, client, image_name, executable):
+        container = client.containers.run(
+            image_name,
+            command=f'./{constants.BUILD_DIRECTORY}/{executable}',
+            working_dir=f'/{project.name}',
+            volumes={f'{os.getcwd()}': {'bind': f'/{project.name}', 'mode': 'rw'}},
+            user=f'{os.getuid()}:{os.getgid()}',
+            detach=True
+        )
+        exit_code = container.wait()
+        result = exit_code['StatusCode']
+        container.remove()
+        if result < 0:
+            print(f'{executable} failed with {result} ({signal.Signals(-result).name})')
+        return result
+
+    def __run_command(self, *args, cwd=constants.BUILD_DIRECTORY):
+        return subprocess.run([*args], cwd=cwd)
+
     def __post_build(self, project):
         return '\n'.join([f'( cd .. && {post_build} )' for post_build in project.target.post_build])
 
-    def tests_from_args(self, project, target_name, files_or_dirs):
+    def tests_from_args(self, project, files_or_dirs):
         if not files_or_dirs:
             return 'tests'
         tests = []
         for arg in files_or_dirs:
             if filesystem.is_file(arg):
-                tests.append(self.test_from_test_file(project, target_name, arg))
+                tests.append(self.test_from_test_file(project, arg))
             elif filesystem.is_directory(arg):
-                tests.extend(self.test_list_from_directory(project, target_name, arg))
+                tests.extend(self.test_list_from_directory(project, arg))
         return tests
 
-    def test_list_from_directory(self, project, target_name, directory):
-        return [self.test_from_test_file(project, target_name, test_file) for test_file in filesystem.find(directory, 'test_*.cpp')]
+    def test_list_from_directory(self, project, directory):
+        return [self.test_from_test_file(project, test_file) for test_file in filesystem.find(directory, 'test_*.cpp')]
 
-    def test_from_test_file(self, project, target_name, test_file):
+    def test_from_test_file(self, project, test_file):
         return next(test for test in project.test.test_suites if test.main == test_file)
 
 

--- a/cpm/domain/test_service.py
+++ b/cpm/domain/test_service.py
@@ -4,13 +4,13 @@ class TestService(object):
         self.cmakelists_builder = cmakelists_builder
         self.project_commands = project_commands
 
-    def run_tests(self, files_or_dirs, target):
-        project = self.project_loader.load('.')
+    def run_tests(self, files_or_dirs, target_name):
+        project = self.project_loader.load('.', target_name)
         if not project.test.test_suites:
             raise NoTestsFound()
         self.cmakelists_builder.build(project)
-        self.project_commands.build_tests(project, target, files_or_dirs)
-        self.project_commands.run_tests(project, target, files_or_dirs)
+        self.project_commands.build_tests(project, files_or_dirs)
+        self.project_commands.run_tests(project, files_or_dirs)
 
 
 class NoTestsFound(RuntimeError):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cpm-cli
-version = 1.5
+version = 1.6.0
 description = Chromos Package Manager
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/test/domain/test_project_composer.py
+++ b/test/domain/test_project_composer.py
@@ -95,7 +95,9 @@ class TestProjectComposer(unittest.TestCase):
                         'libraries': ['pthread']
                     },
                     'post_build': ['./post_build.sh'],
-                    'main': 'main.c'
+                    'main': 'main.c',
+                    'image': 'cpmbits/docker',
+                    'test_image': 'cpmbits/docker_test'
                 }
             }
         }
@@ -113,6 +115,8 @@ class TestProjectComposer(unittest.TestCase):
         assert project.target.include_directories == {'.'}
         assert project.target.post_build == ['./post_build.sh']
         assert project.target.main == 'main.c'
+        assert project.target.image == 'cpmbits/docker'
+        assert project.target.test_image == 'cpmbits/docker_test'
 
     @mock.patch('cpm.domain.project.project_composer.filesystem')
     def test_should_compose_project_from_project_description_with_one_target_test_package(self, filesystem):

--- a/test/domain/test_project_descriptor_parser.py
+++ b/test/domain/test_project_descriptor_parser.py
@@ -84,13 +84,19 @@ class TestProjectDescriptorParser(unittest.TestCase):
             'targets': {
                 'default': {
                     'image': 'cpmbits/bender',
-                    'main': 'main.c'
+                    'main': 'main.c',
+                    'test_image': 'cpmbits/bender_test',
                 }
             }
         }
         project = project_descriptor_parser.parse_yaml(yaml_contents)
         assert project.targets == {
-            'default': project_descriptor.TargetDescription('default', image='cpmbits/bender', main='main.c')
+            'default': project_descriptor.TargetDescription(
+                'default',
+                image='cpmbits/bender',
+                main='main.c',
+                test_image='cpmbits/bender_test'
+            )
         }
 
     def test_parse_project_descriptor_with_target_build_compilation_plan(self):

--- a/test/domain/test_test_service.py
+++ b/test/domain/test_test_service.py
@@ -37,8 +37,8 @@ class TestTestService(unittest.TestCase):
 
         self.project_loader.load.assert_called_once()
         self.cmakelists_builder.build.assert_called_once_with(project)
-        self.project_commands.build_tests.assert_called_once_with(project, 'default', [])
-        self.project_commands.run_tests.assert_called_once_with(project, 'default', [])
+        self.project_commands.build_tests.assert_called_once_with(project, [])
+        self.project_commands.run_tests.assert_called_once_with(project, [])
 
     def test_service_build_ans_runs_only_specified_tests(self):
         project = Project('ProjectName')
@@ -49,5 +49,5 @@ class TestTestService(unittest.TestCase):
 
         self.project_loader.load.assert_called_once()
         self.cmakelists_builder.build.assert_called_once_with(project)
-        self.project_commands.build_tests.assert_called_once_with(project, 'default', ['tests'])
-        self.project_commands.run_tests.assert_called_once_with(project, 'default', ['tests'])
+        self.project_commands.build_tests.assert_called_once_with(project, ['tests'])
+        self.project_commands.run_tests.assert_called_once_with(project, ['tests'])


### PR DESCRIPTION
This MR adds a new configuration parameter in the project target section that allows the user to specify which container to use to run the tests:

```yaml
targets:
  default:
    test_image: 'cpmbits/ubuntu:20.04'
```

When tests are run, they will be compiled and executed using the specified image. This again leverages Docker to handle project dependencies when testing, which are likely to be similar to the build dependencies.