### PR TITLE
Allow defining the toolchain prefix for each target

### DIFF
--- a/cpm/domain/cmake/cmakelists_builder.py
+++ b/cpm/domain/cmake/cmakelists_builder.py
@@ -9,6 +9,8 @@ class CMakeListsBuilder(object):
 
     def build_contents(self, project):
         self.minimum_required('3.7')
+        if project.target.toolchain_prefix:
+            self.set_compilers(project.target.toolchain_prefix)
         self.project(project.name)
         for package in self.bit_packages_with_sources(project.target):
             self.build_package_recipe(package)
@@ -118,3 +120,7 @@ class CMakeListsBuilder(object):
                          f'    {when}\n' \
                          f'    COMMAND COMMAND {command}\n' \
                          f')\n'
+
+    def set_compilers(self, toolchain_prefix):
+        self.contents += f'set(CMAKE_C_COMPILER {toolchain_prefix}gcc)\n'
+        self.contents += f'set(CMAKE_CXX_COMPILER {toolchain_prefix}g++)\n'

--- a/cpm/domain/project/project.py
+++ b/cpm/domain/project/project.py
@@ -21,6 +21,7 @@ class Target:
     image: str = ''
     dockerfile: str = ''
     test_image: str = ''
+    toolchain_prefix: str = ''
     post_build: list = field(default_factory=list)
     packages: list = field(default_factory=list)
     include_directories: set = field(default_factory=set)

--- a/cpm/domain/project/project_composer.py
+++ b/cpm/domain/project/project_composer.py
@@ -26,6 +26,7 @@ def compose_target(target_name, project_descriptor):
     target.image = target_description.image
     target.test_image = target_description.test_image
     target.dockerfile = target_description.dockerfile
+    target.toolchain_prefix = target_description.toolchain_prefix
     target.post_build = target_description.post_build
     compose_packages(project_descriptor.build.packages, target)
     compose_packages(target_description.build.packages, target)

--- a/cpm/domain/project/project_descriptor.py
+++ b/cpm/domain/project/project_descriptor.py
@@ -44,6 +44,7 @@ class TargetDescription:
     dockerfile: str = ''
     image: str = ''
     test_image: str = ''
+    toolchain_prefix: str = ''
 
 
 @dataclass

--- a/cpm/domain/project/project_descriptor_parser.py
+++ b/cpm/domain/project/project_descriptor_parser.py
@@ -37,6 +37,7 @@ def parse_target(target_name, target_description):
     target.image = target_description.get('image', '')
     target.test_image = target_description.get('test_image', '')
     target.dockerfile = target_description.get('dockerfile', '')
+    target.toolchain_prefix = target_description.get('toolchain_prefix', '')
     target.format = target_description.get('format', 'binary')
     target.main = target_description.get('main', '')
     target.post_build = target_description.get('post_build', [])

--- a/test/domain/test_cmakelists_builder.py
+++ b/test/domain/test_cmakelists_builder.py
@@ -30,6 +30,7 @@ class TestCmakelistsBuilder(unittest.TestCase):
             .with_test_bits([test_bit]) \
             .with_test_package('bits/cest', [], []) \
             .with_test_package('bits/mock', ['bits/mock/mock.cpp'], []) \
+            .with_toolchain_prefix('arm-linux-gnueabi-') \
             .sort_include_directories() \
             .project
 
@@ -38,6 +39,8 @@ class TestCmakelistsBuilder(unittest.TestCase):
         print(cmakelists_content)
 
         assert 'cmake_minimum_required (VERSION 3.7)' in cmakelists_content
+        assert 'set(CMAKE_C_COMPILER arm-linux-gnueabi-gcc)' in cmakelists_content
+        assert 'set(CMAKE_CXX_COMPILER arm-linux-gnueabi-g++)' in cmakelists_content
         assert 'project(Project)' in cmakelists_content
         assert 'add_library(package_object_library OBJECT file.cpp file.c)' in cmakelists_content
         assert 'add_library(bit_package_object_library OBJECT bit.cpp bit.c)' in cmakelists_content
@@ -76,6 +79,10 @@ class TestProjectBuilder:
 
     def with_libraries(self, libraries):
         self.project.target.libraries = libraries
+        return self
+
+    def with_toolchain_prefix(self, toolchain_prefix):
+        self.project.target.toolchain_prefix = toolchain_prefix
         return self
 
     def with_package(self, path, sources, cflags):

--- a/test/domain/test_project_composer.py
+++ b/test/domain/test_project_composer.py
@@ -97,7 +97,8 @@ class TestProjectComposer(unittest.TestCase):
                     'post_build': ['./post_build.sh'],
                     'main': 'main.c',
                     'image': 'cpmbits/docker',
-                    'test_image': 'cpmbits/docker_test'
+                    'test_image': 'cpmbits/docker_test',
+                    'toolchain_prefix': 'arm-linux-gnueabi-'
                 }
             }
         }
@@ -117,6 +118,7 @@ class TestProjectComposer(unittest.TestCase):
         assert project.target.main == 'main.c'
         assert project.target.image == 'cpmbits/docker'
         assert project.target.test_image == 'cpmbits/docker_test'
+        assert project.target.toolchain_prefix == 'arm-linux-gnueabi-'
 
     @mock.patch('cpm.domain.project.project_composer.filesystem')
     def test_should_compose_project_from_project_description_with_one_target_test_package(self, filesystem):

--- a/test/domain/test_project_descriptor_parser.py
+++ b/test/domain/test_project_descriptor_parser.py
@@ -86,6 +86,7 @@ class TestProjectDescriptorParser(unittest.TestCase):
                     'image': 'cpmbits/bender',
                     'main': 'main.c',
                     'test_image': 'cpmbits/bender_test',
+                    'toolchain_prefix': 'arm-linux-gnueabi-'
                 }
             }
         }
@@ -95,7 +96,8 @@ class TestProjectDescriptorParser(unittest.TestCase):
                 'default',
                 image='cpmbits/bender',
                 main='main.c',
-                test_image='cpmbits/bender_test'
+                test_image='cpmbits/bender_test',
+                toolchain_prefix='arm-linux-gnueabi-'
             )
         }
 

--- a/test/e2e/environment/Dockerfile
+++ b/test/e2e/environment/Dockerfile
@@ -2,4 +2,4 @@ FROM ubuntu:20.04
 
 RUN apt-get update
 RUN apt install -yq ninja-build g++ cmake
-
+RUN apt-get install -yq gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf

--- a/test/e2e/test_cpm.py
+++ b/test/e2e/test_cpm.py
@@ -77,6 +77,14 @@ class TestCpm(unittest.TestCase):
         result = build.execute([])
         assert result == Result(0, 'Build finished')
 
+    def test_build_from_docker_image_with_toolchain_prefix(self):
+        os.chdir(self.PROJECT_DIRECTORY)
+        self.set_target_dockerfile('default', f'../environment')
+        self.set_toolchain_prefix('default', 'arm-linux-gnueabihf-')
+        install.execute(['-s', 'http://localhost:8000'])
+        result = build.execute([])
+        assert result == Result(0, 'Build finished')
+
     def test_run_tests_from_docker_image(self):
         os.chdir(self.PROJECT_DIRECTORY)
         self.add_bit('test', 'cest', '1.0')
@@ -187,6 +195,11 @@ class TestCpm(unittest.TestCase):
     def set_target_image(self, target_name, image):
         self.modify_descriptor(
             lambda descriptor: descriptor.setdefault('targets', {}).setdefault(target_name, {}).update({'image': image})
+        )
+
+    def set_toolchain_prefix(self, target_name, toolchain_prefix):
+        self.modify_descriptor(
+            lambda descriptor: descriptor.setdefault('targets', {}).setdefault(target_name, {}).update({'toolchain_prefix': toolchain_prefix})
         )
 
     def set_target_test_image(self, target_name, image):


### PR DESCRIPTION
This pull request adds a new configuration parameter to the project descriptor, allowing the user to specify the toolchain prefix. This allows the user full control over the compiler to be used for the compilation of a specific target. The toolchain prefix is prepended to the compiler name, in this case `gcc`. 

Usage:

```yaml
targets:
  default:
    toolchain_prefix: 'arm-linux-gnueabihf-'
```