### PR TITLE
Allow forwarding cpm command line arguments to test mains

### DIFF
--- a/cpm/domain/project_commands.py
+++ b/cpm/domain/project_commands.py
@@ -53,7 +53,8 @@ class ProjectCommands(object):
 
     def __build_using_image(self, project, image_name, goals, post_build):
         client = docker.from_env()
-        print(f'pulling {image_name}')
+        image_metadata = client.images.get(image_name)
+        print(f'using {image_name} ({sizeof_fmt(image_metadata.attrs["Size"])})')
         try:
             client.images.pull(image_name)
         except docker.errors.ImageNotFound:
@@ -166,6 +167,14 @@ def _ignore_exception(call):
         call()
     except:
         pass
+
+
+def sizeof_fmt(num, suffix='B'):
+    for unit in ['', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'Zi']:
+        if abs(num) < 1024.0:
+            return "%3.1f%s%s" % (num, unit, suffix)
+        num /= 1024.0
+    return "%.1f%s%s" % (num, 'Yi', suffix)
 
 
 class TestsFailed(RuntimeError):

--- a/cpm/domain/project_commands.py
+++ b/cpm/domain/project_commands.py
@@ -1,5 +1,4 @@
 import os
-import shlex
 
 import docker
 import subprocess
@@ -53,8 +52,7 @@ class ProjectCommands(object):
 
     def __build_using_image(self, project, image_name, goals, post_build):
         client = docker.from_env()
-        image_metadata = client.images.get(image_name)
-        print(f'using {image_name} ({sizeof_fmt(image_metadata.attrs["Size"])})')
+        print(f'using Docker image {image_name}')
         try:
             client.images.pull(image_name)
         except docker.errors.ImageNotFound:

--- a/cpm/domain/project_commands.py
+++ b/cpm/domain/project_commands.py
@@ -93,24 +93,24 @@ class ProjectCommands(object):
             raise BuildError
         container.remove()
 
-    def run_tests(self, project, files_or_dirs):
+    def run_tests(self, project, files_or_dirs, test_args=()):
         tests_to_run = project.test.test_suites if not files_or_dirs else self.tests_from_args(project, files_or_dirs)
         if project.target.test_image:
-            test_results = self.__run_tests_inside_container(project, tests_to_run)
+            test_results = self.__run_tests_inside_container(project, tests_to_run, test_args)
         else:
-            test_results = [self.run_test(test.name) for test in tests_to_run]
+            test_results = [self.run_test(test.name, test_args) for test in tests_to_run]
         if any(result != 0 for result in test_results):
             raise TestsFailed('tests failed')
 
-    def run_test(self, executable):
+    def run_test(self, executable, test_args):
         result = subprocess.run(
-            [f'./{constants.BUILD_DIRECTORY}/{executable}']
+            [f'./{constants.BUILD_DIRECTORY}/{executable}'] + test_args
         )
         if result.returncode < 0:
             print(f'{executable} failed with {result.returncode} ({signal.Signals(-result.returncode).name})')
         return result.returncode
 
-    def __run_tests_inside_container(self, project, tests_to_run):
+    def __run_tests_inside_container(self, project, tests_to_run, test_args):
         client = docker.from_env()
         image_name = project.target.test_image
         try:
@@ -119,12 +119,12 @@ class ProjectCommands(object):
             raise DockerImageNotFound(image_name)
         except docker.errors.NotFound:
             raise DockerImageNotFound(image_name)
-        return [self.__run_test_inside_container(project, client, image_name, test.name) for test in tests_to_run]
+        return [self.__run_test_inside_container(project, client, image_name, test.name, test_args) for test in tests_to_run]
 
-    def __run_test_inside_container(self, project, client, image_name, executable):
+    def __run_test_inside_container(self, project, client, image_name, executable, test_args):
         container = client.containers.run(
             image_name,
-            command=f'./{constants.BUILD_DIRECTORY}/{executable}',
+            command=f'./{constants.BUILD_DIRECTORY}/{executable} {" ".join(test_args)}',
             working_dir=f'/{project.name}',
             volumes={f'{os.getcwd()}': {'bind': f'/{project.name}', 'mode': 'rw'}},
             user=f'{os.getuid()}:{os.getgid()}',

--- a/cpm/domain/test_service.py
+++ b/cpm/domain/test_service.py
@@ -4,13 +4,13 @@ class TestService(object):
         self.cmakelists_builder = cmakelists_builder
         self.project_commands = project_commands
 
-    def run_tests(self, files_or_dirs, target_name):
+    def run_tests(self, files_or_dirs, target_name, test_args=()):
         project = self.project_loader.load('.', target_name)
         if not project.test.test_suites:
             raise NoTestsFound()
         self.cmakelists_builder.build(project)
         self.project_commands.build_tests(project, files_or_dirs)
-        self.project_commands.run_tests(project, files_or_dirs)
+        self.project_commands.run_tests(project, files_or_dirs, test_args)
 
 
 class NoTestsFound(RuntimeError):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-urllib3
-mock
-pyyaml
-requests
-docker
-ninja
-cmake

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,9 +9,10 @@ author = Jordi Sánchez
 url = https://github.com/jorsanpe/cpm
 
 classifiers =
-  Development Status :: 4 - Beta
+  Development Status :: 5 - Production/Stable
   Environment :: Console
   Programming Language :: Python :: 3
+  Programming Language :: C++
   License :: OSI Approved :: GNU General Public License v3 (GPLv3)
   Operating System :: OS Independent
 

--- a/test/api/test_api_test.py
+++ b/test/api/test_api_test.py
@@ -16,7 +16,7 @@ class TestApiTest(unittest.TestCase):
         result = run_tests(test_service)
 
         assert result.status_code == 1
-        test_service.run_tests.assert_called_once_with([], 'default', [])
+        test_service.run_tests.assert_called_once_with((), 'default', ())
 
     def test_run_tests_fails_when_no_tests_are_found(self):
         test_service = mock.MagicMock()
@@ -25,7 +25,7 @@ class TestApiTest(unittest.TestCase):
         result = run_tests(test_service)
 
         assert result.status_code == 0
-        test_service.run_tests.assert_called_once_with([], 'default', [])
+        test_service.run_tests.assert_called_once_with((), 'default', ())
 
     def test_run_tests_fails_when_compilation_fails(self):
         test_service = mock.MagicMock()
@@ -34,7 +34,7 @@ class TestApiTest(unittest.TestCase):
         result = run_tests(test_service)
 
         assert result.status_code == 1
-        test_service.run_tests.assert_called_once_with([], 'default', [])
+        test_service.run_tests.assert_called_once_with((), 'default', ())
 
     def test_run_tests_fails_when_tests_fail(self):
         test_service = mock.MagicMock()
@@ -43,7 +43,7 @@ class TestApiTest(unittest.TestCase):
         result = run_tests(test_service)
 
         assert result.status_code == 1
-        test_service.run_tests.assert_called_once_with([], 'default', [])
+        test_service.run_tests.assert_called_once_with((), 'default', ())
 
     def test_run_project_tests(self):
         test_service = mock.MagicMock()
@@ -51,7 +51,7 @@ class TestApiTest(unittest.TestCase):
         result = run_tests(test_service)
 
         assert result.status_code == 0
-        test_service.run_tests.assert_called_once_with([], 'default', [])
+        test_service.run_tests.assert_called_once_with((), 'default', ())
 
     def test_run_project_tests_with_patterns(self):
         test_service = mock.MagicMock()
@@ -59,7 +59,7 @@ class TestApiTest(unittest.TestCase):
         result = run_tests(test_service, files_or_dirs=['tests'])
 
         assert result.status_code == 0
-        test_service.run_tests.assert_called_once_with(['tests'], 'default', [])
+        test_service.run_tests.assert_called_once_with(['tests'], 'default', ())
 
     def test_run_project_tests_with_target_other_than_default(self):
         test_service = mock.MagicMock()
@@ -67,7 +67,7 @@ class TestApiTest(unittest.TestCase):
         result = run_tests(test_service, target='rpi4')
 
         assert result.status_code == 0
-        test_service.run_tests.assert_called_once_with([], 'rpi4', [])
+        test_service.run_tests.assert_called_once_with((), 'rpi4', ())
 
     def test_run_project_tests_with_test_args(self):
         test_service = mock.MagicMock()
@@ -75,4 +75,4 @@ class TestApiTest(unittest.TestCase):
         result = run_tests(test_service, test_args=['arg1'])
 
         assert result.status_code == 0
-        test_service.run_tests.assert_called_once_with([], 'default', ['arg1'])
+        test_service.run_tests.assert_called_once_with((), 'default', ['arg1'])

--- a/test/api/test_api_test.py
+++ b/test/api/test_api_test.py
@@ -16,7 +16,7 @@ class TestApiTest(unittest.TestCase):
         result = run_tests(test_service)
 
         assert result.status_code == 1
-        test_service.run_tests.assert_called_once_with([], 'default')
+        test_service.run_tests.assert_called_once_with([], 'default', [])
 
     def test_run_tests_fails_when_no_tests_are_found(self):
         test_service = mock.MagicMock()
@@ -25,7 +25,7 @@ class TestApiTest(unittest.TestCase):
         result = run_tests(test_service)
 
         assert result.status_code == 0
-        test_service.run_tests.assert_called_once_with([], 'default')
+        test_service.run_tests.assert_called_once_with([], 'default', [])
 
     def test_run_tests_fails_when_compilation_fails(self):
         test_service = mock.MagicMock()
@@ -34,7 +34,7 @@ class TestApiTest(unittest.TestCase):
         result = run_tests(test_service)
 
         assert result.status_code == 1
-        test_service.run_tests.assert_called_once_with([], 'default')
+        test_service.run_tests.assert_called_once_with([], 'default', [])
 
     def test_run_tests_fails_when_tests_fail(self):
         test_service = mock.MagicMock()
@@ -43,7 +43,7 @@ class TestApiTest(unittest.TestCase):
         result = run_tests(test_service)
 
         assert result.status_code == 1
-        test_service.run_tests.assert_called_once_with([], 'default')
+        test_service.run_tests.assert_called_once_with([], 'default', [])
 
     def test_run_project_tests(self):
         test_service = mock.MagicMock()
@@ -51,7 +51,7 @@ class TestApiTest(unittest.TestCase):
         result = run_tests(test_service)
 
         assert result.status_code == 0
-        test_service.run_tests.assert_called_once_with([], 'default')
+        test_service.run_tests.assert_called_once_with([], 'default', [])
 
     def test_run_project_tests_with_patterns(self):
         test_service = mock.MagicMock()
@@ -59,7 +59,7 @@ class TestApiTest(unittest.TestCase):
         result = run_tests(test_service, files_or_dirs=['tests'])
 
         assert result.status_code == 0
-        test_service.run_tests.assert_called_once_with(['tests'], 'default')
+        test_service.run_tests.assert_called_once_with(['tests'], 'default', [])
 
     def test_run_project_tests_with_target_other_than_default(self):
         test_service = mock.MagicMock()
@@ -67,4 +67,12 @@ class TestApiTest(unittest.TestCase):
         result = run_tests(test_service, target='rpi4')
 
         assert result.status_code == 0
-        test_service.run_tests.assert_called_once_with([], 'rpi4')
+        test_service.run_tests.assert_called_once_with([], 'rpi4', [])
+
+    def test_run_project_tests_with_test_args(self):
+        test_service = mock.MagicMock()
+
+        result = run_tests(test_service, test_args=['arg1'])
+
+        assert result.status_code == 0
+        test_service.run_tests.assert_called_once_with([], 'default', ['arg1'])

--- a/test/domain/test_test_service.py
+++ b/test/domain/test_test_service.py
@@ -38,9 +38,9 @@ class TestTestService(unittest.TestCase):
         self.project_loader.load.assert_called_once()
         self.cmakelists_builder.build.assert_called_once_with(project)
         self.project_commands.build_tests.assert_called_once_with(project, [])
-        self.project_commands.run_tests.assert_called_once_with(project, [])
+        self.project_commands.run_tests.assert_called_once_with(project, [], [])
 
-    def test_service_build_ans_runs_only_specified_tests(self):
+    def test_service_build_and_runs_only_specified_tests(self):
         project = Project('ProjectName')
         project.test.test_suites = ['test']
         self.project_loader.load.return_value = project
@@ -50,4 +50,16 @@ class TestTestService(unittest.TestCase):
         self.project_loader.load.assert_called_once()
         self.cmakelists_builder.build.assert_called_once_with(project)
         self.project_commands.build_tests.assert_called_once_with(project, ['tests'])
-        self.project_commands.run_tests.assert_called_once_with(project, ['tests'])
+        self.project_commands.run_tests.assert_called_once_with(project, ['tests'], [])
+
+    def test_service_passes_test_args_to_run_command(self):
+        project = Project('ProjectName')
+        project.test.test_suites = ['test']
+        self.project_loader.load.return_value = project
+
+        self.test_service.run_tests(['tests'], 'default', test_args=['arg1'])
+
+        self.project_loader.load.assert_called_once()
+        self.cmakelists_builder.build.assert_called_once_with(project)
+        self.project_commands.build_tests.assert_called_once_with(project, ['tests'])
+        self.project_commands.run_tests.assert_called_once_with(project, ['tests'], ['arg1'])

--- a/test/domain/test_test_service.py
+++ b/test/domain/test_test_service.py
@@ -38,7 +38,7 @@ class TestTestService(unittest.TestCase):
         self.project_loader.load.assert_called_once()
         self.cmakelists_builder.build.assert_called_once_with(project)
         self.project_commands.build_tests.assert_called_once_with(project, [])
-        self.project_commands.run_tests.assert_called_once_with(project, [], [])
+        self.project_commands.run_tests.assert_called_once_with(project, [], ())
 
     def test_service_build_and_runs_only_specified_tests(self):
         project = Project('ProjectName')
@@ -50,7 +50,7 @@ class TestTestService(unittest.TestCase):
         self.project_loader.load.assert_called_once()
         self.cmakelists_builder.build.assert_called_once_with(project)
         self.project_commands.build_tests.assert_called_once_with(project, ['tests'])
-        self.project_commands.run_tests.assert_called_once_with(project, ['tests'], [])
+        self.project_commands.run_tests.assert_called_once_with(project, ['tests'], ())
 
     def test_service_passes_test_args_to_run_command(self):
         project = Project('ProjectName')


### PR DESCRIPTION
With this PR, users will be able to send command line arguments to the testing framework:

```bash
cpm test -- -g -f
```

With the above command, the `-g` and `-f` arguments will be forwarded to the test main.

Closes #237 