### PR TITLE
Allow using a Dockerfile for building and running tests

### DIFF
--- a/cpm/domain/project/project_composer.py
+++ b/cpm/domain/project/project_composer.py
@@ -25,8 +25,9 @@ def compose_target(target_name, project_descriptor):
     target.include_directories.update(project_descriptor.build.includes)
     target.main = target_description.main
     target.image = target_description.image
-    target.test_image = target_description.test_image
     target.dockerfile = target_description.dockerfile
+    target.test_image = target_description.test_image
+    target.test_dockerfile = target_description.test_dockerfile
     target.toolchain_prefix = target_description.toolchain_prefix
     target.post_build = target_description.post_build
     compose_packages(project_descriptor.build.packages, target)

--- a/cpm/domain/project/project_descriptor.py
+++ b/cpm/domain/project/project_descriptor.py
@@ -46,6 +46,7 @@ class TargetDescription:
     dockerfile: str = ''
     image: str = ''
     test_image: str = ''
+    test_dockerfile: str = ''
     toolchain_prefix: str = ''
 
 

--- a/cpm/domain/project/project_descriptor_parser.py
+++ b/cpm/domain/project/project_descriptor_parser.py
@@ -40,8 +40,9 @@ def parse_targets(targets_description):
 def parse_target(target_name, target_description):
     target = TargetDescription(target_name)
     target.image = target_description.get('image', '')
-    target.test_image = target_description.get('test_image', '')
     target.dockerfile = target_description.get('dockerfile', '')
+    target.test_image = target_description.get('test_image', '')
+    target.test_dockerfile = target_description.get('test_dockerfile', '')
     target.toolchain_prefix = target_description.get('toolchain_prefix', '')
     target.format = target_description.get('format', 'binary')
     target.main = target_description.get('main', '')

--- a/scripts/cpm
+++ b/scripts/cpm
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.7
+#!/usr/bin/env python3
 import cpm
 
 cpm.main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cpm-cli
-version = 1.7.0
+version = 1.8.0
 description = Chromos Package Manager
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/test/domain/test_project_composer.py
+++ b/test/domain/test_project_composer.py
@@ -99,6 +99,7 @@ class TestProjectComposer(unittest.TestCase):
                     'main': 'main.c',
                     'image': 'cpmbits/docker',
                     'test_image': 'cpmbits/docker_test',
+                    'test_dockerfile': 'test.Dockerfile',
                     'toolchain_prefix': 'arm-linux-gnueabi-'
                 }
             }
@@ -119,6 +120,7 @@ class TestProjectComposer(unittest.TestCase):
         assert project.target.main == 'main.c'
         assert project.target.image == 'cpmbits/docker'
         assert project.target.test_image == 'cpmbits/docker_test'
+        assert project.target.test_dockerfile == 'test.Dockerfile'
         assert project.target.toolchain_prefix == 'arm-linux-gnueabi-'
 
     @mock.patch('cpm.domain.project.project_composer.filesystem')

--- a/test/domain/test_project_descriptor_parser.py
+++ b/test/domain/test_project_descriptor_parser.py
@@ -86,6 +86,7 @@ class TestProjectDescriptorParser(unittest.TestCase):
                     'image': 'cpmbits/bender',
                     'main': 'main.c',
                     'test_image': 'cpmbits/bender_test',
+                    'test_dockerfile': 'test.Dockerfile',
                     'toolchain_prefix': 'arm-linux-gnueabi-'
                 }
             }
@@ -97,6 +98,7 @@ class TestProjectDescriptorParser(unittest.TestCase):
                 image='cpmbits/bender',
                 main='main.c',
                 test_image='cpmbits/bender_test',
+                test_dockerfile='test.Dockerfile',
                 toolchain_prefix='arm-linux-gnueabi-'
             )
         }

--- a/test/e2e/test_cpm.py
+++ b/test/e2e/test_cpm.py
@@ -113,6 +113,17 @@ class TestCpm(unittest.TestCase):
         result = test.execute([])
         assert result.status_code == 0
 
+    def test_run_tests_using_dockerfile(self):
+        os.chdir(self.PROJECT_DIRECTORY)
+        self.add_bit('test', 'cest', '1.0')
+        self.set_target_image('default', 'cpmbits/ubuntu:20.04')
+        self.set_target_test_dockerfile('default', f'../environment/Dockerfile')
+        self.set_test_ldflags(['-Wl,-s'])
+        self.add_test('test_case.cpp')
+        install.execute(['-s', 'http://localhost:8000'])
+        result = test.execute([])
+        assert result.status_code == 0
+
     def test_build_from_docker_image_with_non_default_target(self):
         os.chdir(self.PROJECT_DIRECTORY)
         self.set_target_image('ubuntu', 'cpmbits/ubuntu:20.04')
@@ -266,6 +277,11 @@ class TestCpm(unittest.TestCase):
     def set_target_dockerfile(self, target_name, dockerfile):
         self.modify_descriptor(
             lambda descriptor: descriptor.setdefault('targets', {}).setdefault(target_name, {}).update({'dockerfile': dockerfile})
+        )
+
+    def set_target_test_dockerfile(self, target_name, dockerfile):
+        self.modify_descriptor(
+            lambda descriptor: descriptor.setdefault('targets', {}).setdefault(target_name, {}).update({'test_dockerfile': dockerfile})
         )
 
     def set_target_ldflags(self, target_name, ldflags):


### PR DESCRIPTION
This PR adds an option to the targets section that allows building and running the tests inside a Docker container built using a Dockerfile:

```yaml
targets:
  default:
    test_dockerfile: 'test.Dockerfile'
```